### PR TITLE
Forcing write extended linear address at each beginning of segments

### DIFF
--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -582,47 +582,6 @@ class IntelHex(object):
             # Python 2
             table = ''.join(chr(i).upper() for i in range_g(256))
 
-        # start address record if any
-        if self.start_addr and write_start_addr:
-            keys = dict_keys(self.start_addr)
-            keys.sort()
-            bin = array('B', asbytes('\0'*9))
-            if keys == ['CS','IP']:
-                # Start Segment Address Record
-                bin[0] = 4      # reclen
-                bin[1] = 0      # offset msb
-                bin[2] = 0      # offset lsb
-                bin[3] = 3      # rectyp
-                cs = self.start_addr['CS']
-                bin[4] = (cs >> 8) & 0x0FF
-                bin[5] = cs & 0x0FF
-                ip = self.start_addr['IP']
-                bin[6] = (ip >> 8) & 0x0FF
-                bin[7] = ip & 0x0FF
-                bin[8] = (-sum(bin)) & 0x0FF    # chksum
-                fwrite(':' +
-                       asstr(hexlify(array_tobytes(bin)).translate(table)) +
-                       eol)
-            elif keys == ['EIP']:
-                # Start Linear Address Record
-                bin[0] = 4      # reclen
-                bin[1] = 0      # offset msb
-                bin[2] = 0      # offset lsb
-                bin[3] = 5      # rectyp
-                eip = self.start_addr['EIP']
-                bin[4] = (eip >> 24) & 0x0FF
-                bin[5] = (eip >> 16) & 0x0FF
-                bin[6] = (eip >> 8) & 0x0FF
-                bin[7] = eip & 0x0FF
-                bin[8] = (-sum(bin)) & 0x0FF    # chksum
-                fwrite(':' +
-                       asstr(hexlify(array_tobytes(bin)).translate(table)) +
-                       eol)
-            else:
-                if fclose:
-                    fclose()
-                raise InvalidStartAddressValueError(start_addr=self.start_addr)
-
         # data
         addresses = dict_keys(self._buf)
         addresses.sort()
@@ -709,6 +668,48 @@ class IntelHex(object):
                     high_addr = int(cur_addr>>16)
                     if high_addr > high_ofs:
                         break
+
+        # start address record if any
+        if self.start_addr and write_start_addr:
+            keys = dict_keys(self.start_addr)
+            keys.sort()
+            bin = array('B', asbytes('\0'*9))
+            if keys == ['CS','IP']:
+                # Start Segment Address Record
+                bin[0] = 4      # reclen
+                bin[1] = 0      # offset msb
+                bin[2] = 0      # offset lsb
+                bin[3] = 3      # rectyp
+                cs = self.start_addr['CS']
+                bin[4] = (cs >> 8) & 0x0FF
+                bin[5] = cs & 0x0FF
+                ip = self.start_addr['IP']
+                bin[6] = (ip >> 8) & 0x0FF
+                bin[7] = ip & 0x0FF
+                bin[8] = (-sum(bin)) & 0x0FF    # chksum
+                fwrite(':' +
+                       asstr(hexlify(array_tobytes(bin)).translate(table)) +
+                       eol)
+            elif keys == ['EIP']:
+                # Start Linear Address Record
+                bin[0] = 4      # reclen
+                bin[1] = 0      # offset msb
+                bin[2] = 0      # offset lsb
+                bin[3] = 5      # rectyp
+                eip = self.start_addr['EIP']
+                bin[4] = (eip >> 24) & 0x0FF
+                bin[5] = (eip >> 16) & 0x0FF
+                bin[6] = (eip >> 8) & 0x0FF
+                bin[7] = eip & 0x0FF
+                bin[8] = (-sum(bin)) & 0x0FF    # chksum
+                fwrite(':' +
+                       asstr(hexlify(array_tobytes(bin)).translate(table)) +
+                       eol)
+            else:
+                if fclose:
+                    fclose()
+                raise InvalidStartAddressValueError(start_addr=self.start_addr)
+
 
         # end-of-file record
         fwrite(":00000001FF"+eol)

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -544,7 +544,8 @@ class IntelHex(object):
             raise ValueError("wrong eolstyle %s" % repr(eolstyle))
     _get_eol_textfile = staticmethod(_get_eol_textfile)
 
-    def write_hex_file(self, f, write_start_addr=True, eolstyle='native'):
+    def write_hex_file(self, f, write_start_addr=True,
+                       eolstyle='native', write_ela=False):
         """Write data to file f in HEX format.
 
         @param  f                   filename or file-like object for writing
@@ -555,6 +556,8 @@ class IntelHex(object):
         @param  eolstyle            can be used to force CRLF line-endings
                                     for output file on different platforms.
                                     Supported eol styles: 'native', 'CRLF'.
+        @param  write_ela           force re-writing extended linear address
+                                    at each beginning of segments if True.
         """
         fwrite = getattr(f, "write", None)
         if fwrite:
@@ -693,7 +696,11 @@ class IntelHex(object):
                     # adjust cur_addr/cur_ix
                     cur_ix += chain_len
                     if cur_ix < addr_len:
-                        cur_addr = addresses[cur_ix]
+                        if write_ela and (addresses[cur_ix] - cur_addr > 0x10):
+                            cur_addr = addresses[cur_ix]
+                            break
+                        else:
+                            cur_addr = addresses[cur_ix]
                     else:
                         cur_addr = maxaddr + 1
                         break


### PR DESCRIPTION
I had a problem with my da14580 chip programmer.

The programmer will not be able to read the HEX file correctly if Extended Linear Address record are not repeated at each beginning of segment.

Here an option to method write_hex_file to add this functionnality.