### PR TITLE
Add IntelHex.find (follows semantics of bytes.find and str.find)

### DIFF
--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -764,6 +764,22 @@ class IntelHex(object):
         self.puts(addr, s)
         self._buf[addr+len(s)] = 0
 
+    def find(self, sub, start=None, end=None):
+        """Return the lowest index in self[start:end] where subsection sub is found.
+        Optional arguments start and end are interpreted as in slice notation.
+        
+        @param  sub     bytes-like subsection to find
+        @param  start   start of section to search within (optional)
+        @param  end     end of section to search within (optional)
+        """
+        sub = bytes(sub)
+        for start, end in self[slice(start,end)].segments():
+            b = self.gets(start, end-start)
+            i = b.find(sub)
+            if i != -1:
+                return start+i
+        return -1
+
     def dump(self, tofile=None, width=16, withpadding=False):
         """Dump object content to specified file object or to stdout if None.
         Format is a hexdump with some header information at the beginning,

--- a/intelhex/test.py
+++ b/intelhex/test.py
@@ -964,6 +964,50 @@ class TestIntelHexGetPutString(TestIntelHexBase):
         self.ih.putsz(0x03, asbytes('hello'))
         self.assertEqual(asbytes('\x00\x01\x02hello\x00\x09'), self.ih.gets(0, 10))
 
+    def test_find(self):
+        self.assertEqual(0, self.ih.find(asbytes('\x00\x01\x02\x03\x04\x05\x06')))
+        self.assertEqual(0, self.ih.find(asbytes('\x00')))
+        self.assertEqual(3, self.ih.find(asbytes('\x03\x04\x05\x06')))
+        self.assertEqual(3, self.ih.find(asbytes('\x03')))
+        self.assertEqual(7, self.ih.find(asbytes('\x07\x08\x09')))
+        self.assertEqual(7, self.ih.find(asbytes('\x07')))
+        self.assertEqual(-1, self.ih.find(asbytes('\x0a')))
+        self.assertEqual(-1, self.ih.find(asbytes('\x02\x01')))
+        self.assertEqual(-1, self.ih.find(asbytes('\x08\x07')))
+
+    def test_find_start(self):
+        self.assertEqual(-1, self.ih.find(asbytes('\x00\x01\x02\x03\x04\x05\x06'), start=3))
+        self.assertEqual(-1, self.ih.find(asbytes('\x00'), start=3))
+        self.assertEqual(3, self.ih.find(asbytes('\x03\x04\x05\x06'), start=3))
+        self.assertEqual(3, self.ih.find(asbytes('\x03'), start=3))
+        self.assertEqual(7, self.ih.find(asbytes('\x07\x08\x09'), start=3))
+        self.assertEqual(7, self.ih.find(asbytes('\x07'), start=3))
+        self.assertEqual(-1, self.ih.find(asbytes('\x0a'), start=3))
+        self.assertEqual(-1, self.ih.find(asbytes('\x02\x01'), start=3))
+        self.assertEqual(-1, self.ih.find(asbytes('\x08\x07'), start=3))
+
+    def test_find_end(self):
+        self.assertEqual(-1, self.ih.find(asbytes('\x00\x01\x02\x03\x04\x05\x06'), end=4))
+        self.assertEqual(0, self.ih.find(asbytes('\x00'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x03\x04\x05\x06'), end=4))
+        self.assertEqual(3, self.ih.find(asbytes('\x03'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x07\x08\x09'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x07'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x0a'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x02\x01'), end=4))
+        self.assertEqual(-1, self.ih.find(asbytes('\x08\x07'), end=4))
+
+    def test_find_start_end(self):
+        self.assertEqual(-1, self.ih.find(asbytes('\x00\x01\x02\x03\x04\x05\x06'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x00'), start=3, end=7))
+        self.assertEqual(3, self.ih.find(asbytes('\x03\x04\x05\x06'), start=3, end=7))
+        self.assertEqual(3, self.ih.find(asbytes('\x03'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x07\x08\x09'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x07'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x0a'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x02\x01'), start=3, end=7))
+        self.assertEqual(-1, self.ih.find(asbytes('\x08\x07'), start=3, end=7))
+
 
 class TestIntelHexDump(TestIntelHexBase):
 


### PR DESCRIPTION
Sometimes we want to find substrings (really sub-byte-arrays) in a binary file that has already been loaded as IntelHex. This PR adds a .find method which follows the same semantics of the standard library bytes.find and str.find methods, returning the index (in this case address) of the start of the substring if found, or -1 otherwise.

The current implementation converts each segment to a bytes object with .gets and then calls the built-in find method, returning if found. This is likely not the fastest implementation, but it is the simplest and can be upgraded later without changing the interface.