### PR TITLE
Bump scripts version to allow tests to pass.

### DIFF
--- a/scripts/bin2hex.py
+++ b/scripts/bin2hex.py
@@ -35,7 +35,7 @@
 
 '''Intel HEX file format bin2hex convertor utility.'''
 
-VERSION = '2.2'
+VERSION = '2.2.1'
 
 if __name__ == '__main__':
     import getopt

--- a/scripts/hex2bin.py
+++ b/scripts/hex2bin.py
@@ -35,7 +35,7 @@
 
 '''Intel HEX file format hex2bin convertor utility.'''
 
-VERSION = '2.2'
+VERSION = '2.2.1'
 
 if __name__ == '__main__':
     import getopt

--- a/scripts/hex2dump.py
+++ b/scripts/hex2dump.py
@@ -35,7 +35,7 @@
 
 """Show content of hex file as hexdump."""
 
-VERSION = '2.2'
+VERSION = '2.2.1'
 
 USAGE = '''hex2dump: show content of hex file as hexdump.
 Usage:

--- a/scripts/hexdiff.py
+++ b/scripts/hexdiff.py
@@ -37,7 +37,7 @@
 of compared data.
 """
 
-VERSION = '2.2'
+VERSION = '2.2.1'
 
 USAGE = '''hexdiff: diff dumps of 2 hex files.
 Usage:

--- a/scripts/hexinfo.py
+++ b/scripts/hexinfo.py
@@ -38,7 +38,7 @@
         data (if any), in YAML format.
 """
 
-VERSION = '2.2'
+VERSION = '2.2.1'
 
 USAGE = '''hexinfo: summarize a hex file's contents.
 Usage:

--- a/scripts/hexmerge.py
+++ b/scripts/hexmerge.py
@@ -35,7 +35,7 @@
 
 """Merge content of several hex files into one file."""
 
-VERSION = '2.2'
+VERSION = '2.2.1'
 
 USAGE = '''hexmerge: merge content of hex files.
 Usage:


### PR DESCRIPTION
Currently, when run `./setup.py test`, following errors can be seen:

```
======================================================================
FAIL: test_sripts_hexmerge_version (intelhex.test.TestInSubprocess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/intelhex-2.2.1/intelhex/test.py", line 1660, in test_sripts_hexmerge_version
    self.versionChecker('%s scripts/hexmerge.py --version')
  File "/build/intelhex-2.2.1/intelhex/test.py", line 1641, in versionChecker
    self.assertEqual(version_str, output.rstrip())
AssertionError: '2.2.1' != '2.2'
- 2.2.1
?    --
+ 2.2
```

Bumping version in scripts resolves the issue.

