### PR TITLE
Fix install to target with buildroot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,11 @@
 """Setup script for IntelHex."""
 
 import sys, glob
-from distutils.core import Command, setup
+from distutils.core import Command
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 import intelhex, intelhex.__version__
 


### PR DESCRIPTION
setup from `distutils.core` doesn't handle parameters sent by buildroot's setuptools