### PR TITLE
Modified write_hex_file() to support big endian mode

### DIFF
--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -544,7 +544,8 @@ class IntelHex(object):
             raise ValueError("wrong eolstyle %s" % repr(eolstyle))
     _get_eol_textfile = staticmethod(_get_eol_textfile)
 
-    def write_hex_file(self, f, write_start_addr=True, eolstyle='native', byte_count=16, endian_mode='little'):
+    def write_hex_file(self, f, write_start_addr=True, eolstyle='native',
+                       byte_count=16, endian_mode='little', word_size_bytes=2):
         """Write data to file f in HEX format.
 
         @param  f                   filename or file-like object for writing
@@ -557,6 +558,8 @@ class IntelHex(object):
                                     Supported eol styles: 'native', 'CRLF'.
         @param byte_count           number of bytes in the data field
         @param endian_mode          supported endian modes: 'little', 'big'.
+        @param word_size_bytes      determines the size of each word in bytes
+                                    in order to format the endian mode correctly
         """
         if byte_count > 255 or byte_count < 1:
             raise ValueError("wrong byte_count value: %s" % byte_count)
@@ -630,7 +633,7 @@ class IntelHex(object):
                 rev_b[loc] = value
                 byte_num += 1
                 i = loc
-                if byte_num >= byte_count:
+                if byte_num >= word_size_bytes:
                     for loc2 in rev_b.keys():
                         self._buf[loc2] = rev_b[i]
                         i -= 1

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -53,12 +53,14 @@ from intelhex.compat import (
     dict_keys_g,
     range_g,
     range_l,
-    )
+)
 
 from intelhex.getsizeof import total_size
 
+
 class _DeprecatedParam(object):
     pass
+
 
 _DEPRECATED = _DeprecatedParam()
 
@@ -67,6 +69,7 @@ class IntelHex(object):
     ''' Intel HEX file reader. '''
 
     def __init__(self, source=None):
+        print("Got intelhex from my modified file!")
         ''' Constructor. If source specified, object will be initialized
         with the contents of source. Otherwise the object will be empty.
 
@@ -107,7 +110,7 @@ class IntelHex(object):
         '''
         s = s.rstrip('\r\n')
         if not s:
-            return          # empty line
+            return  # empty line
 
         if s[0] == ':':
             try:
@@ -125,7 +128,7 @@ class IntelHex(object):
         if length != (5 + record_length):
             raise RecordLengthError(line=line)
 
-        addr = bin[1]*256 + bin[2]
+        addr = bin[1] * 256 + bin[2]
 
         record_type = bin[3]
         if not (0 <= record_type <= 5):
@@ -139,13 +142,13 @@ class IntelHex(object):
         if record_type == 0:
             # data record
             addr += self._offset
-            for i in range_g(4, 4+record_length):
+            for i in range_g(4, 4 + record_length):
                 if not self._buf.get(addr, None) is None:
                     raise AddressOverlapError(address=addr, line=line)
                 self._buf[addr] = bin[i]
-                addr += 1   # FIXME: addr should be wrapped 
-                            # BUT after 02 record (at 64K boundary)
-                            # and after 04 record (at 4G boundary)
+                addr += 1  # FIXME: addr should be wrapped
+                # BUT after 02 record (at 64K boundary)
+                # and after 04 record (at 4G boundary)
 
         elif record_type == 1:
             # end of file record
@@ -157,13 +160,13 @@ class IntelHex(object):
             # Extended 8086 Segment Record
             if record_length != 2 or addr != 0:
                 raise ExtendedSegmentAddressRecordError(line=line)
-            self._offset = (bin[4]*256 + bin[5]) * 16
+            self._offset = (bin[4] * 256 + bin[5]) * 16
 
         elif record_type == 4:
             # Extended Linear Address Record
             if record_length != 2 or addr != 0:
                 raise ExtendedLinearAddressRecordError(line=line)
-            self._offset = (bin[4]*256 + bin[5]) * 65536
+            self._offset = (bin[4] * 256 + bin[5]) * 65536
 
         elif record_type == 3:
             # Start Segment Address Record
@@ -171,9 +174,9 @@ class IntelHex(object):
                 raise StartSegmentAddressRecordError(line=line)
             if self.start_addr:
                 raise DuplicateStartAddressRecordError(line=line)
-            self.start_addr = {'CS': bin[4]*256 + bin[5],
-                               'IP': bin[6]*256 + bin[7],
-                              }
+            self.start_addr = {'CS': bin[4] * 256 + bin[5],
+                               'IP': bin[6] * 256 + bin[7],
+                               }
 
         elif record_type == 5:
             # Start Linear Address Record
@@ -181,11 +184,11 @@ class IntelHex(object):
                 raise StartLinearAddressRecordError(line=line)
             if self.start_addr:
                 raise DuplicateStartAddressRecordError(line=line)
-            self.start_addr = {'EIP': (bin[4]*16777216 +
-                                       bin[5]*65536 +
-                                       bin[6]*256 +
+            self.start_addr = {'EIP': (bin[4] * 16777216 +
+                                       bin[5] * 65536 +
+                                       bin[6] * 256 +
                                        bin[7]),
-                              }
+                               }
 
     def loadhex(self, fobj):
         """Load hex file into internal buffer. This is not necessary
@@ -250,7 +253,7 @@ class IntelHex(object):
             self.loadbin(fobj)
         else:
             raise ValueError('format should be either "hex" or "bin";'
-                ' got %r instead' % format)
+                             ' got %r instead' % format)
 
     # alias (to be consistent with method tofile)
     fromfile = loadfile
@@ -288,9 +291,9 @@ class IntelHex(object):
     def _get_start_end(self, start=None, end=None, size=None):
         """Return default values for start and end if they are None.
         If this IntelHex object is empty then it's error to
-        invoke this method with both start and end as None. 
+        invoke this method with both start and end as None.
         """
-        if (start,end) == (None,None) and self._buf == {}:
+        if (start, end) == (None, None) and self._buf == {}:
             raise EmptyIntelHexError
         if size is not None:
             if None not in (start, end):
@@ -304,7 +307,7 @@ class IntelHex(object):
                 start = end - size + 1
                 if start < 0:
                     raise ValueError("tobinarray: invalid size (%d) "
-                                     "for given end address (%d)" % (size,end))
+                                     "for given end address (%d)" % (size, end))
         else:
             if start is None:
                 start = self.minaddr()
@@ -315,7 +318,7 @@ class IntelHex(object):
         return start, end
 
     def tobinarray(self, start=None, end=None, pad=_DEPRECATED, size=None):
-        ''' Convert this object to binary form as array. If start and end 
+        ''' Convert this object to binary form as array. If start and end
         unspecified, they will be inferred from the data.
         @param  start   start address of output bytes.
         @param  end     end address of output bytes (inclusive).
@@ -326,12 +329,12 @@ class IntelHex(object):
         @return         array of unsigned char data.
         '''
         if not isinstance(pad, _DeprecatedParam):
-            print ("IntelHex.tobinarray: 'pad' parameter is deprecated.")
+            print("IntelHex.tobinarray: 'pad' parameter is deprecated.")
             if pad is not None:
-                print ("Please, use IntelHex.padding attribute instead.")
+                print("Please, use IntelHex.padding attribute instead.")
             else:
-                print ("Please, don't pass it explicitly.")
-                print ("Use syntax like this: ih.tobinarray(start=xxx, end=yyy, size=zzz)")
+                print("Please, don't pass it explicitly.")
+                print("Use syntax like this: ih.tobinarray(start=xxx, end=yyy, size=zzz)")
         else:
             pad = None
         return self._tobinarray_really(start, end, pad, size)
@@ -346,7 +349,7 @@ class IntelHex(object):
         if size is not None and size <= 0:
             raise ValueError("tobinarray: wrong value for size")
         start, end = self._get_start_end(start, end, size)
-        for i in range_g(start, end+1):
+        for i in range_g(start, end + 1):
             bin.append(self._buf.get(i, pad))
         return bin
 
@@ -361,12 +364,12 @@ class IntelHex(object):
         @return         bytes string of binary data.
         '''
         if not isinstance(pad, _DeprecatedParam):
-            print ("IntelHex.tobinstr: 'pad' parameter is deprecated.")
+            print("IntelHex.tobinstr: 'pad' parameter is deprecated.")
             if pad is not None:
-                print ("Please, use IntelHex.padding attribute instead.")
+                print("Please, use IntelHex.padding attribute instead.")
             else:
-                print ("Please, don't pass it explicitly.")
-                print ("Use syntax like this: ih.tobinstr(start=xxx, end=yyy, size=zzz)")
+                print("Please, don't pass it explicitly.")
+                print("Use syntax like this: ih.tobinstr(start=xxx, end=yyy, size=zzz)")
         else:
             pad = None
         return self._tobinstr_really(start, end, pad, size)
@@ -386,12 +389,12 @@ class IntelHex(object):
         @param  size    size of the block, used with start or end parameter.
         '''
         if not isinstance(pad, _DeprecatedParam):
-            print ("IntelHex.tobinfile: 'pad' parameter is deprecated.")
+            print("IntelHex.tobinfile: 'pad' parameter is deprecated.")
             if pad is not None:
-                print ("Please, use IntelHex.padding attribute instead.")
+                print("Please, use IntelHex.padding attribute instead.")
             else:
-                print ("Please, don't pass it explicitly.")
-                print ("Use syntax like this: ih.tobinfile(start=xxx, end=yyy, size=zzz)")
+                print("Please, don't pass it explicitly.")
+                print("Use syntax like this: ih.tobinfile(start=xxx, end=yyy, size=zzz)")
         else:
             pad = None
         if getattr(fobj, "write", None) is None:
@@ -418,7 +421,7 @@ class IntelHex(object):
 
     def addresses(self):
         '''Returns all used addresses in sorted order.
-        @return         list of occupied data addresses in sorted order. 
+        @return         list of occupied data addresses in sorted order.
         '''
         aa = dict_keys(self._buf)
         aa.sort()
@@ -445,6 +448,7 @@ class IntelHex(object):
             return max(aa)
 
     def __getitem__(self, addr):
+        print("Called other version of __getitem__")
         ''' Get requested byte from address.
         @param  addr    address of byte.
         @return         byte if address exists in HEX file, or self.padding
@@ -461,7 +465,7 @@ class IntelHex(object):
             if addresses:
                 addresses.sort()
                 start = addr.start or addresses[0]
-                stop = addr.stop or (addresses[-1]+1)
+                stop = addr.stop or (addresses[-1] + 1)
                 step = addr.step or 1
                 for i in range_g(start, stop, step):
                     x = self._buf.get(i)
@@ -488,7 +492,7 @@ class IntelHex(object):
                 ra = range_l(start, stop, step)
                 if len(ra) != len(byte):
                     raise ValueError('Length of bytes sequence does not match '
-                        'address range')
+                                     'address range')
             elif (start, stop) == (None, None):
                 raise TypeError('Unsupported address range')
             elif start is None:
@@ -518,7 +522,7 @@ class IntelHex(object):
             if addresses:
                 addresses.sort()
                 start = addr.start or addresses[0]
-                stop = addr.stop or (addresses[-1]+1)
+                stop = addr.stop or (addresses[-1] + 1)
                 step = addr.step or 1
                 for i in range_g(start, stop, step):
                     x = self._buf.get(i)
@@ -541,9 +545,11 @@ class IntelHex(object):
                 return '\n'
         else:
             raise ValueError("wrong eolstyle %s" % repr(eolstyle))
+
     _get_eol_textfile = staticmethod(_get_eol_textfile)
 
-    def write_hex_file(self, f, write_start_addr=True, eolstyle='native', byte_count=16):
+    def write_hex_file(self, f, write_start_addr=True, eolstyle='native', byte_count=16, endian_mode='little'):
+        print("Called modified version of write_hex_file!")
         """Write data to file f in HEX format.
 
         @param  f                   filename or file-like object for writing
@@ -555,6 +561,7 @@ class IntelHex(object):
                                     for output file on different platforms.
                                     Supported eol styles: 'native', 'CRLF'.
         @param byte_count           number of bytes in the data field
+        @param endian_mode          supported endian modes: 'little', 'big'.
         """
         if byte_count > 255 or byte_count < 1:
             raise ValueError("wrong byte_count value: %s" % byte_count)
@@ -584,35 +591,35 @@ class IntelHex(object):
         if self.start_addr and write_start_addr:
             keys = dict_keys(self.start_addr)
             keys.sort()
-            bin = array('B', asbytes('\0'*9))
-            if keys == ['CS','IP']:
+            bin = array('B', asbytes('\0' * 9))
+            if keys == ['CS', 'IP']:
                 # Start Segment Address Record
-                bin[0] = 4      # reclen
-                bin[1] = 0      # offset msb
-                bin[2] = 0      # offset lsb
-                bin[3] = 3      # rectyp
+                bin[0] = 4  # reclen
+                bin[1] = 0  # offset msb
+                bin[2] = 0  # offset lsb
+                bin[3] = 3  # rectyp
                 cs = self.start_addr['CS']
                 bin[4] = (cs >> 8) & 0x0FF
                 bin[5] = cs & 0x0FF
                 ip = self.start_addr['IP']
                 bin[6] = (ip >> 8) & 0x0FF
                 bin[7] = ip & 0x0FF
-                bin[8] = (-sum(bin)) & 0x0FF    # chksum
+                bin[8] = (-sum(bin)) & 0x0FF  # chksum
                 fwrite(':' +
                        asstr(hexlify(array_tobytes(bin)).translate(table)) +
                        eol)
             elif keys == ['EIP']:
                 # Start Linear Address Record
-                bin[0] = 4      # reclen
-                bin[1] = 0      # offset msb
-                bin[2] = 0      # offset lsb
-                bin[3] = 5      # rectyp
+                bin[0] = 4  # reclen
+                bin[1] = 0  # offset msb
+                bin[2] = 0  # offset lsb
+                bin[3] = 5  # rectyp
                 eip = self.start_addr['EIP']
                 bin[4] = (eip >> 24) & 0x0FF
                 bin[5] = (eip >> 16) & 0x0FF
                 bin[6] = (eip >> 8) & 0x0FF
                 bin[7] = eip & 0x0FF
-                bin[8] = (-sum(bin)) & 0x0FF    # chksum
+                bin[8] = (-sum(bin)) & 0x0FF  # chksum
                 fwrite(':' +
                        asstr(hexlify(array_tobytes(bin)).translate(table)) +
                        eol)
@@ -620,6 +627,20 @@ class IntelHex(object):
                 if fclose:
                     fclose()
                 raise InvalidStartAddressValueError(start_addr=self.start_addr)
+
+        if endian_mode == 'big':  # reverse data bytes before writing to bin
+            rev_b = {}
+            byte_num = 0
+            for loc, value in self._buf.items():
+                rev_b[loc] = value
+                byte_num += 1
+                i = loc
+                if byte_num >= byte_count:
+                    for loc2 in rev_b.keys():
+                        self._buf[loc2] = rev_b[i]
+                        i -= 1
+                    byte_num = 0
+                    rev_b.clear()
 
         # data
         addresses = dict_keys(self._buf)
@@ -640,16 +661,16 @@ class IntelHex(object):
 
             while cur_addr <= maxaddr:
                 if need_offset_record:
-                    bin = array('B', asbytes('\0'*7))
-                    bin[0] = 2      # reclen
-                    bin[1] = 0      # offset msb
-                    bin[2] = 0      # offset lsb
-                    bin[3] = 4      # rectyp
-                    high_ofs = int(cur_addr>>16)
+                    bin = array('B', asbytes('\0' * 7))
+                    bin[0] = 2  # reclen
+                    bin[1] = 0  # offset msb
+                    bin[2] = 0  # offset lsb
+                    bin[3] = 4  # rectyp
+                    high_ofs = int(cur_addr >> 16)
                     b = divmod(high_ofs, 256)
-                    bin[4] = b[0]   # msb of high_ofs
-                    bin[5] = b[1]   # lsb of high_ofs
-                    bin[6] = (-sum(bin)) & 0x0FF    # chksum
+                    bin[4] = b[0]  # msb of high_ofs
+                    bin[5] = b[1]  # lsb of high_ofs
+                    bin[6] = (-sum(bin)) & 0x0FF  # chksum
                     fwrite(':' +
                            asstr(hexlify(array_tobytes(bin)).translate(table)) +
                            eol)
@@ -658,36 +679,36 @@ class IntelHex(object):
                     # produce one record
                     low_addr = cur_addr & 0x0FFFF
                     # chain_len off by 1
-                    chain_len = min(byte_count-1, 65535-low_addr, maxaddr-cur_addr)
+                    chain_len = min(byte_count - 1, 65535 - low_addr, maxaddr - cur_addr)
 
                     # search continuous chain
                     stop_addr = cur_addr + chain_len
                     if chain_len:
                         ix = bisect_right(addresses, stop_addr,
                                           cur_ix,
-                                          min(cur_ix+chain_len+1, addr_len))
-                        chain_len = ix - cur_ix     # real chain_len
+                                          min(cur_ix + chain_len + 1, addr_len))
+                        chain_len = ix - cur_ix  # real chain_len
                         # there could be small holes in the chain
                         # but we will catch them by try-except later
                         # so for big continuous files we will work
                         # at maximum possible speed
                     else:
-                        chain_len = 1               # real chain_len
+                        chain_len = 1  # real chain_len
 
-                    bin = array('B', asbytes('\0'*(5+chain_len)))
+                    bin = array('B', asbytes('\0' * (5 + chain_len)))
                     b = divmod(low_addr, 256)
-                    bin[1] = b[0]   # msb of low_addr
-                    bin[2] = b[1]   # lsb of low_addr
-                    bin[3] = 0          # rectype
-                    try:    # if there is small holes we'll catch them
+                    bin[1] = b[0]  # msb of low_addr
+                    bin[2] = b[1]  # lsb of low_addr
+                    bin[3] = 0  # rectype
+                    try:  # if there is small holes we'll catch them
                         for i in range_g(chain_len):
-                            bin[4+i] = self._buf[cur_addr+i]
+                            bin[4 + i] = self._buf[cur_addr + i]
                     except KeyError:
                         # we catch a hole so we should shrink the chain
                         chain_len = i
-                        bin = bin[:5+i]
+                        bin = bin[:5 + i]
                     bin[0] = chain_len
-                    bin[4+chain_len] = (-sum(bin)) & 0x0FF    # chksum
+                    bin[4 + chain_len] = (-sum(bin)) & 0x0FF  # chksum
                     fwrite(':' +
                            asstr(hexlify(array_tobytes(bin)).translate(table)) +
                            eol)
@@ -699,12 +720,12 @@ class IntelHex(object):
                     else:
                         cur_addr = maxaddr + 1
                         break
-                    high_addr = int(cur_addr>>16)
+                    high_addr = int(cur_addr >> 16)
                     if high_addr > high_ofs:
                         break
 
         # end-of-file record
-        fwrite(":00000001FF"+eol)
+        fwrite(":00000001FF" + eol)
         if fclose:
             fclose()
 
@@ -720,17 +741,17 @@ class IntelHex(object):
             self.tobinfile(fobj)
         else:
             raise ValueError('format should be either "hex" or "bin";'
-                ' got %r instead' % format)
+                             ' got %r instead' % format)
 
     def gets(self, addr, length):
         """Get string of bytes from given address. If any entries are blank
         from addr through addr+length, a NotEnoughDataError exception will
         be raised. Padding is not used.
         """
-        a = array('B', asbytes('\0'*length))
+        a = array('B', asbytes('\0' * length))
         try:
             for i in range_g(length):
-                a[i] = self._buf[addr+i]
+                a[i] = self._buf[addr + i]
         except KeyError:
             raise NotEnoughDataError(address=addr, length=length)
         return array_tobytes(a)
@@ -741,27 +762,27 @@ class IntelHex(object):
         """
         a = array('B', asbytes(s))
         for i in range_g(len(a)):
-            self._buf[addr+i] = a[i]
+            self._buf[addr + i] = a[i]
 
     def getsz(self, addr):
-        """Get zero-terminated bytes string from given address. Will raise 
+        """Get zero-terminated bytes string from given address. Will raise
         NotEnoughDataError exception if a hole is encountered before a 0.
         """
         i = 0
         try:
             while True:
-                if self._buf[addr+i] == 0:
+                if self._buf[addr + i] == 0:
                     break
                 i += 1
         except KeyError:
             raise NotEnoughDataError(msg=('Bad access at 0x%X: '
-                'not enough data to read zero-terminated string') % addr)
+                                          'not enough data to read zero-terminated string') % addr)
         return self.gets(addr, i)
 
     def putsz(self, addr, s):
         """Put bytes string in object at addr and append terminating zero at end."""
         self.puts(addr, s)
-        self._buf[addr+len(s)] = 0
+        self._buf[addr + len(s)] = 0
 
     def dump(self, tofile=None, width=16, withpadding=False):
         """Dump object content to specified file object or to stdout if None.
@@ -774,13 +795,13 @@ class IntelHex(object):
         @raise  ValueError      if width is not a positive integer
         """
 
-        if not isinstance(width,int) or width < 1:
+        if not isinstance(width, int) or width < 1:
             raise ValueError('width must be a positive integer.')
         # The integer can be of float type - does not work with bit operations
         width = int(width)
         if tofile is None:
             tofile = sys.stdout
-            
+
         # start addr possibly
         if self.start_addr is not None:
             cs = self.start_addr.get('CS')
@@ -800,7 +821,7 @@ class IntelHex(object):
             maxaddr = addresses[-1]
             startaddr = (minaddr // width) * width
             endaddr = ((maxaddr // width) + 1) * width
-            maxdigits = max(len(hex(endaddr)) - 2, 4)   # Less 2 to exclude '0x'
+            maxdigits = max(len(hex(endaddr)) - 2, 4)  # Less 2 to exclude '0x'
             templa = '%%0%dX' % maxdigits
             rangewidth = range_l(width)
             if withpadding:
@@ -812,10 +833,10 @@ class IntelHex(object):
                 tofile.write(' ')
                 s = []
                 for j in rangewidth:
-                    x = self._buf.get(i+j, pad)
+                    x = self._buf.get(i + j, pad)
                     if x is not None:
                         tofile.write(' %02X' % x)
-                        if 32 <= x < 127:   # GNU less does not like 0x7F (128 decimal) so we'd better show it as dot
+                        if 32 <= x < 127:  # GNU less does not like 0x7F (128 decimal) so we'd better show it as dot
                             s.append(chr(x))
                         else:
                             s.append('.')
@@ -835,7 +856,7 @@ class IntelHex(object):
                                   in overlapping region.
 
         @raise  TypeError       if other is not instance of IntelHex
-        @raise  ValueError      if other is the same object as self 
+        @raise  ValueError      if other is the same object as self
                                 (it can't merge itself)
         @raise  ValueError      if overlap argument has incorrect value
         @raise  AddressOverlapError    on overlapped data
@@ -847,7 +868,7 @@ class IntelHex(object):
             raise ValueError("Can't merge itself")
         if overlap not in ('error', 'ignore', 'replace'):
             raise ValueError("overlap argument should be either "
-                "'error', 'ignore' or 'replace'")
+                             "'error', 'ignore' or 'replace'")
         # merge data
         this_buf = self._buf
         other_buf = other._buf
@@ -861,11 +882,11 @@ class IntelHex(object):
             this_buf[i] = other_buf[i]
         # merge start_addr
         if self.start_addr != other.start_addr:
-            if self.start_addr is None:     # set start addr from other
+            if self.start_addr is None:  # set start addr from other
                 self.start_addr = other.start_addr
             elif other.start_addr is None:  # keep existing start addr
                 pass
-            else:                           # conflict
+            else:  # conflict
                 if overlap == 'error':
                     raise AddressOverlapError(
                         'Starting addresses are different')
@@ -881,15 +902,15 @@ class IntelHex(object):
         if not addresses:
             return []
         elif len(addresses) == 1:
-            return([(addresses[0], addresses[0]+1)])
+            return ([(addresses[0], addresses[0] + 1)])
         adjacent_differences = [(b - a) for (a, b) in zip(addresses[:-1], addresses[1:])]
         breaks = [i for (i, x) in enumerate(adjacent_differences) if x > 1]
         endings = [addresses[b] for b in breaks]
         endings.append(addresses[-1])
-        beginings = [addresses[b+1] for b in breaks]
+        beginings = [addresses[b + 1] for b in breaks]
         beginings.insert(0, addresses[0])
-        return [(a, b+1) for (a, b) in zip(beginings, endings)]
-        
+        return [(a, b + 1) for (a, b) in zip(beginings, endings)]
+
     def get_memory_size(self):
         """Returns the approximate memory footprint for data."""
         n = sys.getsizeof(self)
@@ -899,7 +920,8 @@ class IntelHex(object):
         n += sys.getsizeof(self._offset)
         return n
 
-#/IntelHex
+
+# /IntelHex
 
 
 class IntelHex16bit(IntelHex):
@@ -934,6 +956,7 @@ class IntelHex16bit(IntelHex):
             self.padding = 0x0FFFF
 
     def __getitem__(self, addr16):
+        print("Calling modified version of __getitem__!")
         """Get 16-bit word from address.
         Raise error if only one byte from the pair is set.
         We assume a Little Endian interpretation of the hex file.
@@ -948,7 +971,7 @@ class IntelHex16bit(IntelHex):
         byte2 = self._buf.get(addr2, None)
 
         if byte1 != None and byte2 != None:
-            return byte2 | (byte1 << 8)     # low endian
+            return byte2 | (byte1 << 8)  # low endian
 
         if byte1 == None and byte2 == None:
             return self.padding
@@ -956,12 +979,13 @@ class IntelHex16bit(IntelHex):
         raise BadAccess16bit(address=addr16)
 
     def __setitem__(self, addr16, word):
+        print("Calling modded version of __setitem__")
         """Sets the address at addr16 to word assuming Little Endian mode.
         """
         addr_byte = addr16 * 2
         b = divmod(word, 256)
         self._buf[addr_byte] = b[1]
-        self._buf[addr_byte+1] = b[0]
+        self._buf[addr_byte + 1] = b[0]
 
     def minaddr(self):
         '''Get minimal address of HEX content in 16-bit mode.
@@ -972,18 +996,18 @@ class IntelHex16bit(IntelHex):
         if aa == []:
             return 0
         else:
-            return min(aa)>>1
+            return min(aa) >> 1
 
     def maxaddr(self):
         '''Get maximal address of HEX content in 16-bit mode.
 
-        @return         maximal address used in this object 
+        @return         maximal address used in this object
         '''
         aa = dict_keys(self._buf)
         if aa == []:
             return 0
         else:
-            return max(aa)>>1
+            return max(aa) >> 1
 
     def tobinarray(self, start=None, end=None, size=None):
         '''Convert this object to binary form as array (of 2-bytes word data).
@@ -1004,13 +1028,13 @@ class IntelHex16bit(IntelHex):
 
         start, end = self._get_start_end(start, end, size)
 
-        for addr in range_g(start, end+1):
+        for addr in range_g(start, end + 1):
             bin.append(self[addr])
 
         return bin
 
 
-#/class IntelHex16bit
+# /class IntelHex16bit
 
 
 def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
@@ -1027,7 +1051,7 @@ def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
     try:
         h = IntelHex(fin)
     except HexReaderError:
-        e = sys.exc_info()[1]     # current exception
+        e = sys.exc_info()[1]  # current exception
         txt = "ERROR: bad HEX file: %s" % str(e)
         print(txt)
         return 1
@@ -1039,7 +1063,7 @@ def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
                 start = h.minaddr()
             end = start + size - 1
         else:
-            if (end+1) >= size:
+            if (end + 1) >= size:
                 start = end + 1 - size
             else:
                 start = 0
@@ -1050,13 +1074,15 @@ def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
             h.padding = pad
         h.tobinfile(fout, start, end)
     except IOError:
-        e = sys.exc_info()[1]     # current exception
+        e = sys.exc_info()[1]  # current exception
         txt = "ERROR: Could not write to file: %s: %s" % (fout, str(e))
         print(txt)
         return 1
 
     return 0
-#/def hex2bin
+
+
+# /def hex2bin
 
 
 def bin2hex(fin, fout, offset=0):
@@ -1071,7 +1097,7 @@ def bin2hex(fin, fout, offset=0):
     try:
         h.loadbin(fin, offset)
     except IOError:
-        e = sys.exc_info()[1]     # current exception
+        e = sys.exc_info()[1]  # current exception
         txt = 'ERROR: unable to load bin file:', str(e)
         print(txt)
         return 1
@@ -1079,13 +1105,15 @@ def bin2hex(fin, fout, offset=0):
     try:
         h.tofile(fout, format='hex')
     except IOError:
-        e = sys.exc_info()[1]     # current exception
+        e = sys.exc_info()[1]  # current exception
         txt = "ERROR: Could not write to file: %s: %s" % (fout, str(e))
         print(txt)
         return 1
 
     return 0
-#/def bin2hex
+
+
+# /def bin2hex
 
 
 def diff_dumps(ih1, ih2, tofile=None, name1="a", name2="b", n_context=3):
@@ -1099,19 +1127,21 @@ def diff_dumps(ih1, ih2, tofile=None, name1="a", name2="b", n_context=3):
     @param name2      name of the first hex file to show in the diff header
     @param n_context  number of context lines in the unidiff output
     """
+
     def prepare_lines(ih):
         sio = StringIO()
         ih.dump(sio)
         dump = sio.getvalue()
         lines = dump.splitlines()
         return lines
+
     a = prepare_lines(ih1)
     b = prepare_lines(ih2)
     import difflib
     result = list(difflib.unified_diff(a, b, fromfile=name1, tofile=name2, n=n_context, lineterm=''))
     if tofile is None:
         tofile = sys.stdout
-    output = '\n'.join(result)+'\n'
+    output = '\n'.join(result) + '\n'
     tofile.write(output)
 
 
@@ -1131,6 +1161,7 @@ class Record(object):
         s = (-sum(bytes)) & 0x0FF
         bin = array('B', bytes + [s])
         return ':' + asstr(hexlify(array_tobytes(bin))).upper()
+
     _from_bytes = staticmethod(_from_bytes)
 
     def data(offset, bytes):
@@ -1145,15 +1176,17 @@ class Record(object):
         """
         assert 0 <= offset < 65536
         assert 0 < len(bytes) < 256
-        b = [len(bytes), (offset>>8)&0x0FF, offset&0x0FF, 0x00] + bytes
+        b = [len(bytes), (offset >> 8) & 0x0FF, offset & 0x0FF, 0x00] + bytes
         return Record._from_bytes(b)
+
     data = staticmethod(data)
 
     def eof():
         """Return End of File record as a string.
-        @return         String representation of Intel Hex EOF record 
+        @return         String representation of Intel Hex EOF record
         """
         return ':00000001FF'
+
     eof = staticmethod(eof)
 
     def extended_segment_address(usba):
@@ -1162,8 +1195,9 @@ class Record(object):
 
         @return         String representation of Intel Hex USBA record.
         """
-        b = [2, 0, 0, 0x02, (usba>>8)&0x0FF, usba&0x0FF]
+        b = [2, 0, 0, 0x02, (usba >> 8) & 0x0FF, usba & 0x0FF]
         return Record._from_bytes(b)
+
     extended_segment_address = staticmethod(extended_segment_address)
 
     def start_segment_address(cs, ip):
@@ -1173,9 +1207,10 @@ class Record(object):
 
         @return         String representation of Intel Hex SSA record.
         """
-        b = [4, 0, 0, 0x03, (cs>>8)&0x0FF, cs&0x0FF,
-             (ip>>8)&0x0FF, ip&0x0FF]
+        b = [4, 0, 0, 0x03, (cs >> 8) & 0x0FF, cs & 0x0FF,
+             (ip >> 8) & 0x0FF, ip & 0x0FF]
         return Record._from_bytes(b)
+
     start_segment_address = staticmethod(start_segment_address)
 
     def extended_linear_address(ulba):
@@ -1184,8 +1219,9 @@ class Record(object):
 
         @return         String representation of Intel Hex ELA record.
         """
-        b = [2, 0, 0, 0x04, (ulba>>8)&0x0FF, ulba&0x0FF]
+        b = [2, 0, 0, 0x04, (ulba >> 8) & 0x0FF, ulba & 0x0FF]
         return Record._from_bytes(b)
+
     extended_linear_address = staticmethod(extended_linear_address)
 
     def start_linear_address(eip):
@@ -1194,15 +1230,17 @@ class Record(object):
 
         @return         String representation of Intel Hex SLA record.
         """
-        b = [4, 0, 0, 0x05, (eip>>24)&0x0FF, (eip>>16)&0x0FF,
-             (eip>>8)&0x0FF, eip&0x0FF]
+        b = [4, 0, 0, 0x05, (eip >> 24) & 0x0FF, (eip >> 16) & 0x0FF,
+             (eip >> 8) & 0x0FF, eip & 0x0FF]
         return Record._from_bytes(b)
+
     start_linear_address = staticmethod(start_linear_address)
 
 
 class _BadFileNotation(Exception):
     """Special error class to use with _get_file_and_addr_range."""
     pass
+
 
 def _get_file_and_addr_range(s, _support_drive_letter=None):
     """Special method for hexmerge.py script to split file notation
@@ -1214,7 +1252,7 @@ def _get_file_and_addr_range(s, _support_drive_letter=None):
         _support_drive_letter = (os.name == 'nt')
     drive = ''
     if _support_drive_letter:
-        if s[1:2] == ':' and s[0].upper() in ''.join([chr(i) for i in range_g(ord('A'), ord('Z')+1)]):
+        if s[1:2] == ':' and s[0].upper() in ''.join([chr(i) for i in range_g(ord('A'), ord('Z') + 1)]):
             drive = s[:2]
             s = s[2:]
     parts = s.split(':')
@@ -1227,6 +1265,7 @@ def _get_file_and_addr_range(s, _support_drive_letter=None):
         raise _BadFileNotation
     else:
         fname = parts[0]
+
         def ascii_hex_to_int(ascii):
             if ascii is not None:
                 try:
@@ -1234,9 +1273,10 @@ def _get_file_and_addr_range(s, _support_drive_letter=None):
                 except ValueError:
                     raise _BadFileNotation
             return ascii
+
         fstart = ascii_hex_to_int(parts[1] or None)
         fend = ascii_hex_to_int(parts[2] or None)
-    return drive+fname, fstart, fend
+    return drive + fname, fstart, fend
 
 
 ##
@@ -1266,7 +1306,7 @@ def _get_file_and_addr_range(s, _support_drive_letter=None):
 class IntelHexError(Exception):
     '''Base Exception class for IntelHex module'''
 
-    _fmt = 'IntelHex base error'   #: format string
+    _fmt = 'IntelHex base error'  #: format string
 
     def __init__(self, msg=None, **kw):
         """Initialize the Exception with the given message.
@@ -1282,19 +1322,23 @@ class IntelHexError(Exception):
         try:
             return self._fmt % self.__dict__
         except (NameError, ValueError, KeyError):
-            e = sys.exc_info()[1]     # current exception
+            e = sys.exc_info()[1]  # current exception
             return 'Unprintable exception %s: %s' \
-                % (repr(e), str(e))
+                   % (repr(e), str(e))
+
 
 class _EndOfFile(IntelHexError):
     """Used for internal needs only."""
     _fmt = 'EOF record reached -- signal to stop read file'
 
+
 class HexReaderError(IntelHexError):
     _fmt = 'Hex reader base error'
 
+
 class AddressOverlapError(HexReaderError):
     _fmt = 'Hex file has data overlap at address 0x%(address)X on line %(line)d'
+
 
 # class NotAHexFileError was removed in trunk.revno.54 because it's not used
 
@@ -1306,11 +1350,14 @@ class HexRecordError(HexReaderError):
 class RecordLengthError(HexRecordError):
     _fmt = 'Record at line %(line)d has invalid length'
 
+
 class RecordTypeError(HexRecordError):
     _fmt = 'Record at line %(line)d has invalid record type'
 
+
 class RecordChecksumError(HexRecordError):
     _fmt = 'Record at line %(line)d has invalid checksum'
+
 
 class EOFRecordError(HexRecordError):
     _fmt = 'File has invalid End-of-File record'
@@ -1319,8 +1366,10 @@ class EOFRecordError(HexRecordError):
 class ExtendedAddressRecordError(HexRecordError):
     _fmt = 'Base class for extended address exceptions'
 
+
 class ExtendedSegmentAddressRecordError(ExtendedAddressRecordError):
     _fmt = 'Invalid Extended Segment Address Record at line %(line)d'
+
 
 class ExtendedLinearAddressRecordError(ExtendedAddressRecordError):
     _fmt = 'Invalid Extended Linear Address Record at line %(line)d'
@@ -1329,14 +1378,18 @@ class ExtendedLinearAddressRecordError(ExtendedAddressRecordError):
 class StartAddressRecordError(HexRecordError):
     _fmt = 'Base class for start address exceptions'
 
+
 class StartSegmentAddressRecordError(StartAddressRecordError):
     _fmt = 'Invalid Start Segment Address Record at line %(line)d'
+
 
 class StartLinearAddressRecordError(StartAddressRecordError):
     _fmt = 'Invalid Start Linear Address Record at line %(line)d'
 
+
 class DuplicateStartAddressRecordError(StartAddressRecordError):
     _fmt = 'Start Address Record appears twice at line %(line)d'
+
 
 class InvalidStartAddressValueError(StartAddressRecordError):
     _fmt = 'Invalid start address value: %(start_addr)s'
@@ -1346,8 +1399,10 @@ class NotEnoughDataError(IntelHexError):
     _fmt = ('Bad access at 0x%(address)X: '
             'not enough data to read %(length)d contiguous bytes')
 
+
 class BadAccess16bit(NotEnoughDataError):
     _fmt = 'Bad access at 0x%(address)X: not enough data to read 16 bit value'
+
 
 class EmptyIntelHexError(IntelHexError):
     _fmt = "Requested operation cannot be executed with empty object"

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -69,10 +69,8 @@ class IntelHex(object):
     ''' Intel HEX file reader. '''
 
     def __init__(self, source=None):
-        print("Got intelhex from my modified file!")
         ''' Constructor. If source specified, object will be initialized
         with the contents of source. Otherwise the object will be empty.
-
         @param  source      source for initialization
                             (file name of HEX file, file object, addr dict or
                              other IntelHex object)
@@ -102,10 +100,8 @@ class IntelHex(object):
 
     def _decode_record(self, s, line=0):
         '''Decode one record of HEX file.
-
         @param  s       line with HEX record.
         @param  line    line number (for error messages).
-
         @raise  EndOfFile   if EOF record encountered.
         '''
         s = s.rstrip('\r\n')
@@ -194,7 +190,6 @@ class IntelHex(object):
         """Load hex file into internal buffer. This is not necessary
         if object was initialized with source set. This will overwrite
         addresses if object was already initialized.
-
         @param  fobj        file name or file-like object
         """
         if getattr(fobj, "read", None) is None:
@@ -222,7 +217,6 @@ class IntelHex(object):
         """Load bin file into internal buffer. Not needed if source set in
         constructor. This will overwrite addresses without warning
         if object was already initialized.
-
         @param  fobj        file name or file-like object
         @param  offset      starting address offset
         """
@@ -243,7 +237,6 @@ class IntelHex(object):
     def loadfile(self, fobj, format):
         """Load data file into internal buffer. Preferred wrapper over
         loadbin or loadhex.
-
         @param  fobj        file name or file-like object
         @param  format      file format ("hex" or "bin")
         """
@@ -264,7 +257,6 @@ class IntelHex(object):
         those addresses in unsigned char form (i.e. not strings).
         The dictionary may contain the key, ``start_addr``
         to indicate the starting address of the data as described in README.
-
         The contents of the dict will be merged with this object and will
         overwrite any conflicts. This function is not necessary if the
         object was initialized with source specified.
@@ -379,7 +371,6 @@ class IntelHex(object):
 
     def tobinfile(self, fobj, start=None, end=None, pad=_DEPRECATED, size=None):
         '''Convert to binary and write to file.
-
         @param  fobj    file name or file object for writing output bytes.
         @param  start   start address of output bytes.
         @param  end     end address of output bytes (inclusive).
@@ -410,7 +401,6 @@ class IntelHex(object):
 
     def todict(self):
         '''Convert to python dictionary.
-
         @return         dict suitable for initializing another IntelHex object.
         '''
         r = {}
@@ -448,7 +438,6 @@ class IntelHex(object):
             return max(aa)
 
     def __getitem__(self, addr):
-        print("Called other version of __getitem__")
         ''' Get requested byte from address.
         @param  addr    address of byte.
         @return         byte if address exists in HEX file, or self.padding
@@ -549,9 +538,7 @@ class IntelHex(object):
     _get_eol_textfile = staticmethod(_get_eol_textfile)
 
     def write_hex_file(self, f, write_start_addr=True, eolstyle='native', byte_count=16, endian_mode='little'):
-        print("Called modified version of write_hex_file!")
         """Write data to file f in HEX format.
-
         @param  f                   filename or file-like object for writing
         @param  write_start_addr    enable or disable writing start address
                                     record to file (enabled by default).
@@ -731,7 +718,6 @@ class IntelHex(object):
 
     def tofile(self, fobj, format):
         """Write data to hex or bin file. Preferred method over tobin or tohex.
-
         @param  fobj        file name or file-like object
         @param  format      file format ("hex" or "bin")
         """
@@ -788,7 +774,6 @@ class IntelHex(object):
         """Dump object content to specified file object or to stdout if None.
         Format is a hexdump with some header information at the beginning,
         addresses on the left, and data on right.
-
         @param  tofile          file-like object to dump to
         @param  width           number of bytes per line (i.e. columns)
         @param  withpadding     print padding character instead of '--'
@@ -854,7 +839,6 @@ class IntelHex(object):
                                   in overlapping region;
                         - replace: replace data with other data
                                   in overlapping region.
-
         @raise  TypeError       if other is not instance of IntelHex
         @raise  ValueError      if other is the same object as self
                                 (it can't merge itself)
@@ -934,7 +918,6 @@ class IntelHex16bit(IntelHex):
         again because this class will alter it. This class leaves padding
         alone unless it was precisely 0xFF. In that instance it is sign
         extended to 0xFFFF.
-
         @param  source  file name of HEX file or file object
                         or instance of ordinary IntelHex class.
                         Will also accept dictionary from todict method.
@@ -956,11 +939,9 @@ class IntelHex16bit(IntelHex):
             self.padding = 0x0FFFF
 
     def __getitem__(self, addr16):
-        print("Calling modified version of __getitem__!")
         """Get 16-bit word from address.
         Raise error if only one byte from the pair is set.
         We assume a Little Endian interpretation of the hex file.
-
         @param  addr16  address of word (addr8 = 2 * addr16).
         @return         word if bytes exists in HEX file, or self.padding
                         if no data found.
@@ -971,7 +952,7 @@ class IntelHex16bit(IntelHex):
         byte2 = self._buf.get(addr2, None)
 
         if byte1 != None and byte2 != None:
-            return byte2 | (byte1 << 8)  # low endian
+            return byte1 | (byte2 << 8)  # low endian
 
         if byte1 == None and byte2 == None:
             return self.padding
@@ -979,7 +960,6 @@ class IntelHex16bit(IntelHex):
         raise BadAccess16bit(address=addr16)
 
     def __setitem__(self, addr16, word):
-        print("Calling modded version of __setitem__")
         """Sets the address at addr16 to word assuming Little Endian mode.
         """
         addr_byte = addr16 * 2
@@ -989,7 +969,6 @@ class IntelHex16bit(IntelHex):
 
     def minaddr(self):
         '''Get minimal address of HEX content in 16-bit mode.
-
         @return         minimal address used in this object
         '''
         aa = dict_keys(self._buf)
@@ -1000,7 +979,6 @@ class IntelHex16bit(IntelHex):
 
     def maxaddr(self):
         '''Get maximal address of HEX content in 16-bit mode.
-
         @return         maximal address used in this object
         '''
         aa = dict_keys(self._buf)
@@ -1040,7 +1018,6 @@ class IntelHex16bit(IntelHex):
 def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
     """Hex-to-Bin convertor engine.
     @return     0   if all OK
-
     @param  fin     input hex file (filename or file-like object)
     @param  fout    output bin file (filename or file-like object)
     @param  start   start of address range (optional)
@@ -1088,7 +1065,6 @@ def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
 def bin2hex(fin, fout, offset=0):
     """Simple bin-to-hex convertor.
     @return     0   if all OK
-
     @param  fin     input bin file (filename or file-like object)
     @param  fout    output hex file (filename or file-like object)
     @param  offset  starting address offset for loading bin
@@ -1119,7 +1095,6 @@ def bin2hex(fin, fout, offset=0):
 def diff_dumps(ih1, ih2, tofile=None, name1="a", name2="b", n_context=3):
     """Diff 2 IntelHex objects and produce unified diff output for their
     hex dumps.
-
     @param ih1        first IntelHex object to compare
     @param ih2        second IntelHex object to compare
     @param tofile     file-like object to write output
@@ -1152,7 +1127,6 @@ class Record(object):
         """Takes a list of bytes, computes the checksum, and outputs the entire
         record as a string. bytes should be the hex record without the colon
         or final checksum.
-
         @param  bytes   list of byte values so far to pack into record.
         @return         String representation of one HEX record
         """
@@ -1168,10 +1142,8 @@ class Record(object):
         """Return Data record. This constructs the full record, including
         the length information, the record type (0x00), the
         checksum, and the offset.
-
         @param  offset  load offset of first byte.
         @param  bytes   list of byte values to pack into record.
-
         @return         String representation of one HEX record
         """
         assert 0 <= offset < 65536
@@ -1192,7 +1164,6 @@ class Record(object):
     def extended_segment_address(usba):
         """Return Extended Segment Address Record.
         @param  usba     Upper Segment Base Address.
-
         @return         String representation of Intel Hex USBA record.
         """
         b = [2, 0, 0, 0x02, (usba >> 8) & 0x0FF, usba & 0x0FF]
@@ -1204,7 +1175,6 @@ class Record(object):
         """Return Start Segment Address Record.
         @param  cs      16-bit value for CS register.
         @param  ip      16-bit value for IP register.
-
         @return         String representation of Intel Hex SSA record.
         """
         b = [4, 0, 0, 0x03, (cs >> 8) & 0x0FF, cs & 0x0FF,
@@ -1216,7 +1186,6 @@ class Record(object):
     def extended_linear_address(ulba):
         """Return Extended Linear Address Record.
         @param  ulba    Upper Linear Base Address.
-
         @return         String representation of Intel Hex ELA record.
         """
         b = [2, 0, 0, 0x04, (ulba >> 8) & 0x0FF, ulba & 0x0FF]
@@ -1227,7 +1196,6 @@ class Record(object):
     def start_linear_address(eip):
         """Return Start Linear Address Record.
         @param  eip     32-bit linear address for the EIP register.
-
         @return         String representation of Intel Hex SLA record.
         """
         b = [4, 0, 0, 0x05, (eip >> 24) & 0x0FF, (eip >> 16) & 0x0FF,
@@ -1245,7 +1213,6 @@ class _BadFileNotation(Exception):
 def _get_file_and_addr_range(s, _support_drive_letter=None):
     """Special method for hexmerge.py script to split file notation
     into 3 parts: (filename, start, end)
-
     @raise _BadFileNotation  when string cannot be safely split.
     """
     if _support_drive_letter is None:

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -1078,6 +1078,7 @@ def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
 def bin2hex(fin, fout, offset=0):
     """Simple bin-to-hex convertor.
     @return     0   if all OK
+
     @param  fin     input bin file (filename or file-like object)
     @param  fout    output hex file (filename or file-like object)
     @param  offset  starting address offset for loading bin

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -70,6 +70,7 @@ class IntelHex(object):
     def __init__(self, source=None):
         ''' Constructor. If source specified, object will be initialized
         with the contents of source. Otherwise the object will be empty.
+
         @param  source      source for initialization
                             (file name of HEX file, file object, addr dict or
                              other IntelHex object)
@@ -99,8 +100,10 @@ class IntelHex(object):
 
     def _decode_record(self, s, line=0):
         '''Decode one record of HEX file.
+
         @param  s       line with HEX record.
         @param  line    line number (for error messages).
+
         @raise  EndOfFile   if EOF record encountered.
         '''
         s = s.rstrip('\r\n')
@@ -189,6 +192,7 @@ class IntelHex(object):
         """Load hex file into internal buffer. This is not necessary
         if object was initialized with source set. This will overwrite
         addresses if object was already initialized.
+
         @param  fobj        file name or file-like object
         """
         if getattr(fobj, "read", None) is None:
@@ -216,6 +220,7 @@ class IntelHex(object):
         """Load bin file into internal buffer. Not needed if source set in
         constructor. This will overwrite addresses without warning
         if object was already initialized.
+
         @param  fobj        file name or file-like object
         @param  offset      starting address offset
         """
@@ -236,6 +241,7 @@ class IntelHex(object):
     def loadfile(self, fobj, format):
         """Load data file into internal buffer. Preferred wrapper over
         loadbin or loadhex.
+
         @param  fobj        file name or file-like object
         @param  format      file format ("hex" or "bin")
         """
@@ -256,6 +262,7 @@ class IntelHex(object):
         those addresses in unsigned char form (i.e. not strings).
         The dictionary may contain the key, ``start_addr``
         to indicate the starting address of the data as described in README.
+
         The contents of the dict will be merged with this object and will
         overwrite any conflicts. This function is not necessary if the
         object was initialized with source specified.
@@ -370,6 +377,7 @@ class IntelHex(object):
 
     def tobinfile(self, fobj, start=None, end=None, pad=_DEPRECATED, size=None):
         '''Convert to binary and write to file.
+
         @param  fobj    file name or file object for writing output bytes.
         @param  start   start address of output bytes.
         @param  end     end address of output bytes (inclusive).
@@ -400,6 +408,7 @@ class IntelHex(object):
 
     def todict(self):
         '''Convert to python dictionary.
+
         @return         dict suitable for initializing another IntelHex object.
         '''
         r = {}
@@ -537,6 +546,7 @@ class IntelHex(object):
 
     def write_hex_file(self, f, write_start_addr=True, eolstyle='native', byte_count=16, endian_mode='little'):
         """Write data to file f in HEX format.
+
         @param  f                   filename or file-like object for writing
         @param  write_start_addr    enable or disable writing start address
                                     record to file (enabled by default).
@@ -716,6 +726,7 @@ class IntelHex(object):
 
     def tofile(self, fobj, format):
         """Write data to hex or bin file. Preferred method over tobin or tohex.
+
         @param  fobj        file name or file-like object
         @param  format      file format ("hex" or "bin")
         """
@@ -772,6 +783,7 @@ class IntelHex(object):
         """Dump object content to specified file object or to stdout if None.
         Format is a hexdump with some header information at the beginning,
         addresses on the left, and data on right.
+
         @param  tofile          file-like object to dump to
         @param  width           number of bytes per line (i.e. columns)
         @param  withpadding     print padding character instead of '--'
@@ -837,6 +849,7 @@ class IntelHex(object):
                                   in overlapping region;
                         - replace: replace data with other data
                                   in overlapping region.
+
         @raise  TypeError       if other is not instance of IntelHex
         @raise  ValueError      if other is the same object as self 
                                 (it can't merge itself)
@@ -915,6 +928,7 @@ class IntelHex16bit(IntelHex):
         again because this class will alter it. This class leaves padding
         alone unless it was precisely 0xFF. In that instance it is sign
         extended to 0xFFFF.
+
         @param  source  file name of HEX file or file object
                         or instance of ordinary IntelHex class.
                         Will also accept dictionary from todict method.
@@ -939,6 +953,7 @@ class IntelHex16bit(IntelHex):
         """Get 16-bit word from address.
         Raise error if only one byte from the pair is set.
         We assume a Little Endian interpretation of the hex file.
+
         @param  addr16  address of word (addr8 = 2 * addr16).
         @return         word if bytes exists in HEX file, or self.padding
                         if no data found.
@@ -966,6 +981,7 @@ class IntelHex16bit(IntelHex):
 
     def minaddr(self):
         '''Get minimal address of HEX content in 16-bit mode.
+
         @return         minimal address used in this object
         '''
         aa = dict_keys(self._buf)
@@ -976,6 +992,7 @@ class IntelHex16bit(IntelHex):
 
     def maxaddr(self):
         '''Get maximal address of HEX content in 16-bit mode.
+
         @return         maximal address used in this object 
         '''
         aa = dict_keys(self._buf)
@@ -1015,6 +1032,7 @@ class IntelHex16bit(IntelHex):
 def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
     """Hex-to-Bin convertor engine.
     @return     0   if all OK
+
     @param  fin     input hex file (filename or file-like object)
     @param  fout    output bin file (filename or file-like object)
     @param  start   start of address range (optional)
@@ -1088,6 +1106,7 @@ def bin2hex(fin, fout, offset=0):
 def diff_dumps(ih1, ih2, tofile=None, name1="a", name2="b", n_context=3):
     """Diff 2 IntelHex objects and produce unified diff output for their
     hex dumps.
+
     @param ih1        first IntelHex object to compare
     @param ih2        second IntelHex object to compare
     @param tofile     file-like object to write output
@@ -1118,6 +1137,7 @@ class Record(object):
         """Takes a list of bytes, computes the checksum, and outputs the entire
         record as a string. bytes should be the hex record without the colon
         or final checksum.
+
         @param  bytes   list of byte values so far to pack into record.
         @return         String representation of one HEX record
         """
@@ -1132,8 +1152,10 @@ class Record(object):
         """Return Data record. This constructs the full record, including
         the length information, the record type (0x00), the
         checksum, and the offset.
+
         @param  offset  load offset of first byte.
         @param  bytes   list of byte values to pack into record.
+
         @return         String representation of one HEX record
         """
         assert 0 <= offset < 65536
@@ -1152,6 +1174,7 @@ class Record(object):
     def extended_segment_address(usba):
         """Return Extended Segment Address Record.
         @param  usba     Upper Segment Base Address.
+
         @return         String representation of Intel Hex USBA record.
         """
         b = [2, 0, 0, 0x02, (usba>>8)&0x0FF, usba&0x0FF]
@@ -1162,6 +1185,7 @@ class Record(object):
         """Return Start Segment Address Record.
         @param  cs      16-bit value for CS register.
         @param  ip      16-bit value for IP register.
+
         @return         String representation of Intel Hex SSA record.
         """
         b = [4, 0, 0, 0x03, (cs>>8)&0x0FF, cs&0x0FF,
@@ -1172,6 +1196,7 @@ class Record(object):
     def extended_linear_address(ulba):
         """Return Extended Linear Address Record.
         @param  ulba    Upper Linear Base Address.
+
         @return         String representation of Intel Hex ELA record.
         """
         b = [2, 0, 0, 0x04, (ulba>>8)&0x0FF, ulba&0x0FF]
@@ -1181,6 +1206,7 @@ class Record(object):
     def start_linear_address(eip):
         """Return Start Linear Address Record.
         @param  eip     32-bit linear address for the EIP register.
+
         @return         String representation of Intel Hex SLA record.
         """
         b = [4, 0, 0, 0x05, (eip>>24)&0x0FF, (eip>>16)&0x0FF,
@@ -1196,6 +1222,7 @@ class _BadFileNotation(Exception):
 def _get_file_and_addr_range(s, _support_drive_letter=None):
     """Special method for hexmerge.py script to split file notation
     into 3 parts: (filename, start, end)
+
     @raise _BadFileNotation  when string cannot be safely split.
     """
     if _support_drive_letter is None:

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -53,14 +53,13 @@ from intelhex.compat import (
     dict_keys_g,
     range_g,
     range_l,
-)
+    )
 
 from intelhex.getsizeof import total_size
 
 
 class _DeprecatedParam(object):
     pass
-
 
 _DEPRECATED = _DeprecatedParam()
 
@@ -106,7 +105,7 @@ class IntelHex(object):
         '''
         s = s.rstrip('\r\n')
         if not s:
-            return  # empty line
+            return          # empty line
 
         if s[0] == ':':
             try:
@@ -124,7 +123,7 @@ class IntelHex(object):
         if length != (5 + record_length):
             raise RecordLengthError(line=line)
 
-        addr = bin[1] * 256 + bin[2]
+        addr = bin[1]*256 + bin[2]
 
         record_type = bin[3]
         if not (0 <= record_type <= 5):
@@ -138,13 +137,13 @@ class IntelHex(object):
         if record_type == 0:
             # data record
             addr += self._offset
-            for i in range_g(4, 4 + record_length):
+            for i in range_g(4, 4+record_length):
                 if not self._buf.get(addr, None) is None:
                     raise AddressOverlapError(address=addr, line=line)
                 self._buf[addr] = bin[i]
-                addr += 1  # FIXME: addr should be wrapped
-                # BUT after 02 record (at 64K boundary)
-                # and after 04 record (at 4G boundary)
+                addr += 1   # FIXME: addr should be wrapped 
+                            # BUT after 02 record (at 64K boundary)
+                            # and after 04 record (at 4G boundary)
 
         elif record_type == 1:
             # end of file record
@@ -156,13 +155,13 @@ class IntelHex(object):
             # Extended 8086 Segment Record
             if record_length != 2 or addr != 0:
                 raise ExtendedSegmentAddressRecordError(line=line)
-            self._offset = (bin[4] * 256 + bin[5]) * 16
+            self._offset = (bin[4]*256 + bin[5]) * 16
 
         elif record_type == 4:
             # Extended Linear Address Record
             if record_length != 2 or addr != 0:
                 raise ExtendedLinearAddressRecordError(line=line)
-            self._offset = (bin[4] * 256 + bin[5]) * 65536
+            self._offset = (bin[4]*256 + bin[5]) * 65536
 
         elif record_type == 3:
             # Start Segment Address Record
@@ -170,9 +169,9 @@ class IntelHex(object):
                 raise StartSegmentAddressRecordError(line=line)
             if self.start_addr:
                 raise DuplicateStartAddressRecordError(line=line)
-            self.start_addr = {'CS': bin[4] * 256 + bin[5],
-                               'IP': bin[6] * 256 + bin[7],
-                               }
+            self.start_addr = {'CS': bin[4]*256 + bin[5],
+                               'IP': bin[6]*256 + bin[7],
+                              }
 
         elif record_type == 5:
             # Start Linear Address Record
@@ -180,11 +179,11 @@ class IntelHex(object):
                 raise StartLinearAddressRecordError(line=line)
             if self.start_addr:
                 raise DuplicateStartAddressRecordError(line=line)
-            self.start_addr = {'EIP': (bin[4] * 16777216 +
-                                       bin[5] * 65536 +
-                                       bin[6] * 256 +
+            self.start_addr = {'EIP': (bin[4]*16777216 +
+                                       bin[5]*65536 +
+                                       bin[6]*256 +
                                        bin[7]),
-                               }
+                              }
 
     def loadhex(self, fobj):
         """Load hex file into internal buffer. This is not necessary
@@ -246,7 +245,7 @@ class IntelHex(object):
             self.loadbin(fobj)
         else:
             raise ValueError('format should be either "hex" or "bin";'
-                             ' got %r instead' % format)
+                ' got %r instead' % format)
 
     # alias (to be consistent with method tofile)
     fromfile = loadfile
@@ -283,9 +282,9 @@ class IntelHex(object):
     def _get_start_end(self, start=None, end=None, size=None):
         """Return default values for start and end if they are None.
         If this IntelHex object is empty then it's error to
-        invoke this method with both start and end as None.
+        invoke this method with both start and end as None. 
         """
-        if (start, end) == (None, None) and self._buf == {}:
+        if (start,end) == (None,None) and self._buf == {}:
             raise EmptyIntelHexError
         if size is not None:
             if None not in (start, end):
@@ -299,7 +298,7 @@ class IntelHex(object):
                 start = end - size + 1
                 if start < 0:
                     raise ValueError("tobinarray: invalid size (%d) "
-                                     "for given end address (%d)" % (size, end))
+                                     "for given end address (%d)" % (size,end))
         else:
             if start is None:
                 start = self.minaddr()
@@ -310,7 +309,7 @@ class IntelHex(object):
         return start, end
 
     def tobinarray(self, start=None, end=None, pad=_DEPRECATED, size=None):
-        ''' Convert this object to binary form as array. If start and end
+        ''' Convert this object to binary form as array. If start and end 
         unspecified, they will be inferred from the data.
         @param  start   start address of output bytes.
         @param  end     end address of output bytes (inclusive).
@@ -321,12 +320,12 @@ class IntelHex(object):
         @return         array of unsigned char data.
         '''
         if not isinstance(pad, _DeprecatedParam):
-            print("IntelHex.tobinarray: 'pad' parameter is deprecated.")
+            print ("IntelHex.tobinarray: 'pad' parameter is deprecated.")
             if pad is not None:
-                print("Please, use IntelHex.padding attribute instead.")
+                print ("Please, use IntelHex.padding attribute instead.")
             else:
-                print("Please, don't pass it explicitly.")
-                print("Use syntax like this: ih.tobinarray(start=xxx, end=yyy, size=zzz)")
+                print ("Please, don't pass it explicitly.")
+                print ("Use syntax like this: ih.tobinarray(start=xxx, end=yyy, size=zzz)")
         else:
             pad = None
         return self._tobinarray_really(start, end, pad, size)
@@ -341,7 +340,7 @@ class IntelHex(object):
         if size is not None and size <= 0:
             raise ValueError("tobinarray: wrong value for size")
         start, end = self._get_start_end(start, end, size)
-        for i in range_g(start, end + 1):
+        for i in range_g(start, end+1):
             bin.append(self._buf.get(i, pad))
         return bin
 
@@ -356,12 +355,12 @@ class IntelHex(object):
         @return         bytes string of binary data.
         '''
         if not isinstance(pad, _DeprecatedParam):
-            print("IntelHex.tobinstr: 'pad' parameter is deprecated.")
+            print ("IntelHex.tobinstr: 'pad' parameter is deprecated.")
             if pad is not None:
-                print("Please, use IntelHex.padding attribute instead.")
+                print ("Please, use IntelHex.padding attribute instead.")
             else:
-                print("Please, don't pass it explicitly.")
-                print("Use syntax like this: ih.tobinstr(start=xxx, end=yyy, size=zzz)")
+                print ("Please, don't pass it explicitly.")
+                print ("Use syntax like this: ih.tobinstr(start=xxx, end=yyy, size=zzz)")
         else:
             pad = None
         return self._tobinstr_really(start, end, pad, size)
@@ -380,12 +379,12 @@ class IntelHex(object):
         @param  size    size of the block, used with start or end parameter.
         '''
         if not isinstance(pad, _DeprecatedParam):
-            print("IntelHex.tobinfile: 'pad' parameter is deprecated.")
+            print ("IntelHex.tobinfile: 'pad' parameter is deprecated.")
             if pad is not None:
-                print("Please, use IntelHex.padding attribute instead.")
+                print ("Please, use IntelHex.padding attribute instead.")
             else:
-                print("Please, don't pass it explicitly.")
-                print("Use syntax like this: ih.tobinfile(start=xxx, end=yyy, size=zzz)")
+                print ("Please, don't pass it explicitly.")
+                print ("Use syntax like this: ih.tobinfile(start=xxx, end=yyy, size=zzz)")
         else:
             pad = None
         if getattr(fobj, "write", None) is None:
@@ -411,7 +410,7 @@ class IntelHex(object):
 
     def addresses(self):
         '''Returns all used addresses in sorted order.
-        @return         list of occupied data addresses in sorted order.
+        @return         list of occupied data addresses in sorted order. 
         '''
         aa = dict_keys(self._buf)
         aa.sort()
@@ -454,7 +453,7 @@ class IntelHex(object):
             if addresses:
                 addresses.sort()
                 start = addr.start or addresses[0]
-                stop = addr.stop or (addresses[-1] + 1)
+                stop = addr.stop or (addresses[-1]+1)
                 step = addr.step or 1
                 for i in range_g(start, stop, step):
                     x = self._buf.get(i)
@@ -481,7 +480,7 @@ class IntelHex(object):
                 ra = range_l(start, stop, step)
                 if len(ra) != len(byte):
                     raise ValueError('Length of bytes sequence does not match '
-                                     'address range')
+                        'address range')
             elif (start, stop) == (None, None):
                 raise TypeError('Unsupported address range')
             elif start is None:
@@ -511,7 +510,7 @@ class IntelHex(object):
             if addresses:
                 addresses.sort()
                 start = addr.start or addresses[0]
-                stop = addr.stop or (addresses[-1] + 1)
+                stop = addr.stop or (addresses[-1]+1)
                 step = addr.step or 1
                 for i in range_g(start, stop, step):
                     x = self._buf.get(i)
@@ -534,7 +533,6 @@ class IntelHex(object):
                 return '\n'
         else:
             raise ValueError("wrong eolstyle %s" % repr(eolstyle))
-
     _get_eol_textfile = staticmethod(_get_eol_textfile)
 
     def write_hex_file(self, f, write_start_addr=True, eolstyle='native', byte_count=16, endian_mode='little'):
@@ -578,35 +576,35 @@ class IntelHex(object):
         if self.start_addr and write_start_addr:
             keys = dict_keys(self.start_addr)
             keys.sort()
-            bin = array('B', asbytes('\0' * 9))
-            if keys == ['CS', 'IP']:
+            bin = array('B', asbytes('\0'*9))
+            if keys == ['CS','IP']:
                 # Start Segment Address Record
-                bin[0] = 4  # reclen
-                bin[1] = 0  # offset msb
-                bin[2] = 0  # offset lsb
-                bin[3] = 3  # rectyp
+                bin[0] = 4      # reclen
+                bin[1] = 0      # offset msb
+                bin[2] = 0      # offset lsb
+                bin[3] = 3      # rectyp
                 cs = self.start_addr['CS']
                 bin[4] = (cs >> 8) & 0x0FF
                 bin[5] = cs & 0x0FF
                 ip = self.start_addr['IP']
                 bin[6] = (ip >> 8) & 0x0FF
                 bin[7] = ip & 0x0FF
-                bin[8] = (-sum(bin)) & 0x0FF  # chksum
+                bin[8] = (-sum(bin)) & 0x0FF    # chksum
                 fwrite(':' +
                        asstr(hexlify(array_tobytes(bin)).translate(table)) +
                        eol)
             elif keys == ['EIP']:
                 # Start Linear Address Record
-                bin[0] = 4  # reclen
-                bin[1] = 0  # offset msb
-                bin[2] = 0  # offset lsb
-                bin[3] = 5  # rectyp
+                bin[0] = 4      # reclen
+                bin[1] = 0      # offset msb
+                bin[2] = 0      # offset lsb
+                bin[3] = 5      # rectyp
                 eip = self.start_addr['EIP']
                 bin[4] = (eip >> 24) & 0x0FF
                 bin[5] = (eip >> 16) & 0x0FF
                 bin[6] = (eip >> 8) & 0x0FF
                 bin[7] = eip & 0x0FF
-                bin[8] = (-sum(bin)) & 0x0FF  # chksum
+                bin[8] = (-sum(bin)) & 0x0FF    # chksum
                 fwrite(':' +
                        asstr(hexlify(array_tobytes(bin)).translate(table)) +
                        eol)
@@ -648,16 +646,16 @@ class IntelHex(object):
 
             while cur_addr <= maxaddr:
                 if need_offset_record:
-                    bin = array('B', asbytes('\0' * 7))
-                    bin[0] = 2  # reclen
-                    bin[1] = 0  # offset msb
-                    bin[2] = 0  # offset lsb
-                    bin[3] = 4  # rectyp
-                    high_ofs = int(cur_addr >> 16)
+                    bin = array('B', asbytes('\0'*7))
+                    bin[0] = 2      # reclen
+                    bin[1] = 0      # offset msb
+                    bin[2] = 0      # offset lsb
+                    bin[3] = 4      # rectyp
+                    high_ofs = int(cur_addr>>16)
                     b = divmod(high_ofs, 256)
-                    bin[4] = b[0]  # msb of high_ofs
-                    bin[5] = b[1]  # lsb of high_ofs
-                    bin[6] = (-sum(bin)) & 0x0FF  # chksum
+                    bin[4] = b[0]   # msb of high_ofs
+                    bin[5] = b[1]   # lsb of high_ofs
+                    bin[6] = (-sum(bin)) & 0x0FF    # chksum
                     fwrite(':' +
                            asstr(hexlify(array_tobytes(bin)).translate(table)) +
                            eol)
@@ -666,36 +664,36 @@ class IntelHex(object):
                     # produce one record
                     low_addr = cur_addr & 0x0FFFF
                     # chain_len off by 1
-                    chain_len = min(byte_count - 1, 65535 - low_addr, maxaddr - cur_addr)
+                    chain_len = min(byte_count-1, 65535-low_addr, maxaddr-cur_addr)
 
                     # search continuous chain
                     stop_addr = cur_addr + chain_len
                     if chain_len:
                         ix = bisect_right(addresses, stop_addr,
                                           cur_ix,
-                                          min(cur_ix + chain_len + 1, addr_len))
-                        chain_len = ix - cur_ix  # real chain_len
+                                          min(cur_ix+chain_len+1, addr_len))
+                        chain_len = ix - cur_ix     # real chain_len
                         # there could be small holes in the chain
                         # but we will catch them by try-except later
                         # so for big continuous files we will work
                         # at maximum possible speed
                     else:
-                        chain_len = 1  # real chain_len
+                        chain_len = 1               # real chain_len
 
-                    bin = array('B', asbytes('\0' * (5 + chain_len)))
+                    bin = array('B', asbytes('\0'*(5+chain_len)))
                     b = divmod(low_addr, 256)
-                    bin[1] = b[0]  # msb of low_addr
-                    bin[2] = b[1]  # lsb of low_addr
-                    bin[3] = 0  # rectype
-                    try:  # if there is small holes we'll catch them
+                    bin[1] = b[0]   # msb of low_addr
+                    bin[2] = b[1]   # lsb of low_addr
+                    bin[3] = 0          # rectype
+                    try:    # if there is small holes we'll catch them
                         for i in range_g(chain_len):
-                            bin[4 + i] = self._buf[cur_addr + i]
+                            bin[4+i] = self._buf[cur_addr+i]
                     except KeyError:
                         # we catch a hole so we should shrink the chain
                         chain_len = i
-                        bin = bin[:5 + i]
+                        bin = bin[:5+i]
                     bin[0] = chain_len
-                    bin[4 + chain_len] = (-sum(bin)) & 0x0FF  # chksum
+                    bin[4+chain_len] = (-sum(bin)) & 0x0FF    # chksum
                     fwrite(':' +
                            asstr(hexlify(array_tobytes(bin)).translate(table)) +
                            eol)
@@ -707,12 +705,12 @@ class IntelHex(object):
                     else:
                         cur_addr = maxaddr + 1
                         break
-                    high_addr = int(cur_addr >> 16)
+                    high_addr = int(cur_addr>>16)
                     if high_addr > high_ofs:
                         break
 
         # end-of-file record
-        fwrite(":00000001FF" + eol)
+        fwrite(":00000001FF"+eol)
         if fclose:
             fclose()
 
@@ -727,17 +725,17 @@ class IntelHex(object):
             self.tobinfile(fobj)
         else:
             raise ValueError('format should be either "hex" or "bin";'
-                             ' got %r instead' % format)
+                ' got %r instead' % format)
 
     def gets(self, addr, length):
         """Get string of bytes from given address. If any entries are blank
         from addr through addr+length, a NotEnoughDataError exception will
         be raised. Padding is not used.
         """
-        a = array('B', asbytes('\0' * length))
+        a = array('B', asbytes('\0'*length))
         try:
             for i in range_g(length):
-                a[i] = self._buf[addr + i]
+                a[i] = self._buf[addr+i]
         except KeyError:
             raise NotEnoughDataError(address=addr, length=length)
         return array_tobytes(a)
@@ -748,27 +746,27 @@ class IntelHex(object):
         """
         a = array('B', asbytes(s))
         for i in range_g(len(a)):
-            self._buf[addr + i] = a[i]
+            self._buf[addr+i] = a[i]
 
     def getsz(self, addr):
-        """Get zero-terminated bytes string from given address. Will raise
+        """Get zero-terminated bytes string from given address. Will raise 
         NotEnoughDataError exception if a hole is encountered before a 0.
         """
         i = 0
         try:
             while True:
-                if self._buf[addr + i] == 0:
+                if self._buf[addr+i] == 0:
                     break
                 i += 1
         except KeyError:
             raise NotEnoughDataError(msg=('Bad access at 0x%X: '
-                                          'not enough data to read zero-terminated string') % addr)
+                'not enough data to read zero-terminated string') % addr)
         return self.gets(addr, i)
 
     def putsz(self, addr, s):
         """Put bytes string in object at addr and append terminating zero at end."""
         self.puts(addr, s)
-        self._buf[addr + len(s)] = 0
+        self._buf[addr+len(s)] = 0
 
     def dump(self, tofile=None, width=16, withpadding=False):
         """Dump object content to specified file object or to stdout if None.
@@ -780,13 +778,13 @@ class IntelHex(object):
         @raise  ValueError      if width is not a positive integer
         """
 
-        if not isinstance(width, int) or width < 1:
+        if not isinstance(width,int) or width < 1:
             raise ValueError('width must be a positive integer.')
         # The integer can be of float type - does not work with bit operations
         width = int(width)
         if tofile is None:
             tofile = sys.stdout
-
+            
         # start addr possibly
         if self.start_addr is not None:
             cs = self.start_addr.get('CS')
@@ -806,7 +804,7 @@ class IntelHex(object):
             maxaddr = addresses[-1]
             startaddr = (minaddr // width) * width
             endaddr = ((maxaddr // width) + 1) * width
-            maxdigits = max(len(hex(endaddr)) - 2, 4)  # Less 2 to exclude '0x'
+            maxdigits = max(len(hex(endaddr)) - 2, 4)   # Less 2 to exclude '0x'
             templa = '%%0%dX' % maxdigits
             rangewidth = range_l(width)
             if withpadding:
@@ -818,10 +816,10 @@ class IntelHex(object):
                 tofile.write(' ')
                 s = []
                 for j in rangewidth:
-                    x = self._buf.get(i + j, pad)
+                    x = self._buf.get(i+j, pad)
                     if x is not None:
                         tofile.write(' %02X' % x)
-                        if 32 <= x < 127:  # GNU less does not like 0x7F (128 decimal) so we'd better show it as dot
+                        if 32 <= x < 127:   # GNU less does not like 0x7F (128 decimal) so we'd better show it as dot
                             s.append(chr(x))
                         else:
                             s.append('.')
@@ -840,7 +838,7 @@ class IntelHex(object):
                         - replace: replace data with other data
                                   in overlapping region.
         @raise  TypeError       if other is not instance of IntelHex
-        @raise  ValueError      if other is the same object as self
+        @raise  ValueError      if other is the same object as self 
                                 (it can't merge itself)
         @raise  ValueError      if overlap argument has incorrect value
         @raise  AddressOverlapError    on overlapped data
@@ -852,7 +850,7 @@ class IntelHex(object):
             raise ValueError("Can't merge itself")
         if overlap not in ('error', 'ignore', 'replace'):
             raise ValueError("overlap argument should be either "
-                             "'error', 'ignore' or 'replace'")
+                "'error', 'ignore' or 'replace'")
         # merge data
         this_buf = self._buf
         other_buf = other._buf
@@ -866,11 +864,11 @@ class IntelHex(object):
             this_buf[i] = other_buf[i]
         # merge start_addr
         if self.start_addr != other.start_addr:
-            if self.start_addr is None:  # set start addr from other
+            if self.start_addr is None:     # set start addr from other
                 self.start_addr = other.start_addr
             elif other.start_addr is None:  # keep existing start addr
                 pass
-            else:  # conflict
+            else:                           # conflict
                 if overlap == 'error':
                     raise AddressOverlapError(
                         'Starting addresses are different')
@@ -886,15 +884,15 @@ class IntelHex(object):
         if not addresses:
             return []
         elif len(addresses) == 1:
-            return ([(addresses[0], addresses[0] + 1)])
+            return([(addresses[0], addresses[0]+1)])
         adjacent_differences = [(b - a) for (a, b) in zip(addresses[:-1], addresses[1:])]
         breaks = [i for (i, x) in enumerate(adjacent_differences) if x > 1]
         endings = [addresses[b] for b in breaks]
         endings.append(addresses[-1])
-        beginings = [addresses[b + 1] for b in breaks]
+        beginings = [addresses[b+1] for b in breaks]
         beginings.insert(0, addresses[0])
-        return [(a, b + 1) for (a, b) in zip(beginings, endings)]
-
+        return [(a, b+1) for (a, b) in zip(beginings, endings)]
+        
     def get_memory_size(self):
         """Returns the approximate memory footprint for data."""
         n = sys.getsizeof(self)
@@ -904,8 +902,7 @@ class IntelHex(object):
         n += sys.getsizeof(self._offset)
         return n
 
-
-# /IntelHex
+#/IntelHex
 
 
 class IntelHex16bit(IntelHex):
@@ -952,7 +949,7 @@ class IntelHex16bit(IntelHex):
         byte2 = self._buf.get(addr2, None)
 
         if byte1 != None and byte2 != None:
-            return byte1 | (byte2 << 8)  # low endian
+            return byte1 | (byte2 << 8)     # low endian
 
         if byte1 == None and byte2 == None:
             return self.padding
@@ -965,7 +962,7 @@ class IntelHex16bit(IntelHex):
         addr_byte = addr16 * 2
         b = divmod(word, 256)
         self._buf[addr_byte] = b[1]
-        self._buf[addr_byte + 1] = b[0]
+        self._buf[addr_byte+1] = b[0]
 
     def minaddr(self):
         '''Get minimal address of HEX content in 16-bit mode.
@@ -975,17 +972,17 @@ class IntelHex16bit(IntelHex):
         if aa == []:
             return 0
         else:
-            return min(aa) >> 1
+            return min(aa)>>1
 
     def maxaddr(self):
         '''Get maximal address of HEX content in 16-bit mode.
-        @return         maximal address used in this object
+        @return         maximal address used in this object 
         '''
         aa = dict_keys(self._buf)
         if aa == []:
             return 0
         else:
-            return max(aa) >> 1
+            return max(aa)>>1
 
     def tobinarray(self, start=None, end=None, size=None):
         '''Convert this object to binary form as array (of 2-bytes word data).
@@ -1006,13 +1003,13 @@ class IntelHex16bit(IntelHex):
 
         start, end = self._get_start_end(start, end, size)
 
-        for addr in range_g(start, end + 1):
+        for addr in range_g(start, end+1):
             bin.append(self[addr])
 
         return bin
 
 
-# /class IntelHex16bit
+#/class IntelHex16bit
 
 
 def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
@@ -1028,7 +1025,7 @@ def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
     try:
         h = IntelHex(fin)
     except HexReaderError:
-        e = sys.exc_info()[1]  # current exception
+        e = sys.exc_info()[1]     # current exception
         txt = "ERROR: bad HEX file: %s" % str(e)
         print(txt)
         return 1
@@ -1040,7 +1037,7 @@ def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
                 start = h.minaddr()
             end = start + size - 1
         else:
-            if (end + 1) >= size:
+            if (end+1) >= size:
                 start = end + 1 - size
             else:
                 start = 0
@@ -1051,15 +1048,13 @@ def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
             h.padding = pad
         h.tobinfile(fout, start, end)
     except IOError:
-        e = sys.exc_info()[1]  # current exception
+        e = sys.exc_info()[1]     # current exception
         txt = "ERROR: Could not write to file: %s: %s" % (fout, str(e))
         print(txt)
         return 1
 
     return 0
-
-
-# /def hex2bin
+#/def hex2bin
 
 
 def bin2hex(fin, fout, offset=0):
@@ -1073,7 +1068,7 @@ def bin2hex(fin, fout, offset=0):
     try:
         h.loadbin(fin, offset)
     except IOError:
-        e = sys.exc_info()[1]  # current exception
+        e = sys.exc_info()[1]     # current exception
         txt = 'ERROR: unable to load bin file:', str(e)
         print(txt)
         return 1
@@ -1081,15 +1076,13 @@ def bin2hex(fin, fout, offset=0):
     try:
         h.tofile(fout, format='hex')
     except IOError:
-        e = sys.exc_info()[1]  # current exception
+        e = sys.exc_info()[1]     # current exception
         txt = "ERROR: Could not write to file: %s: %s" % (fout, str(e))
         print(txt)
         return 1
 
     return 0
-
-
-# /def bin2hex
+#/def bin2hex
 
 
 def diff_dumps(ih1, ih2, tofile=None, name1="a", name2="b", n_context=3):
@@ -1102,21 +1095,19 @@ def diff_dumps(ih1, ih2, tofile=None, name1="a", name2="b", n_context=3):
     @param name2      name of the first hex file to show in the diff header
     @param n_context  number of context lines in the unidiff output
     """
-
     def prepare_lines(ih):
         sio = StringIO()
         ih.dump(sio)
         dump = sio.getvalue()
         lines = dump.splitlines()
         return lines
-
     a = prepare_lines(ih1)
     b = prepare_lines(ih2)
     import difflib
     result = list(difflib.unified_diff(a, b, fromfile=name1, tofile=name2, n=n_context, lineterm=''))
     if tofile is None:
         tofile = sys.stdout
-    output = '\n'.join(result) + '\n'
+    output = '\n'.join(result)+'\n'
     tofile.write(output)
 
 
@@ -1135,7 +1126,6 @@ class Record(object):
         s = (-sum(bytes)) & 0x0FF
         bin = array('B', bytes + [s])
         return ':' + asstr(hexlify(array_tobytes(bin))).upper()
-
     _from_bytes = staticmethod(_from_bytes)
 
     def data(offset, bytes):
@@ -1148,17 +1138,15 @@ class Record(object):
         """
         assert 0 <= offset < 65536
         assert 0 < len(bytes) < 256
-        b = [len(bytes), (offset >> 8) & 0x0FF, offset & 0x0FF, 0x00] + bytes
+        b = [len(bytes), (offset>>8)&0x0FF, offset&0x0FF, 0x00] + bytes
         return Record._from_bytes(b)
-
     data = staticmethod(data)
 
     def eof():
         """Return End of File record as a string.
-        @return         String representation of Intel Hex EOF record
+        @return         String representation of Intel Hex EOF record 
         """
         return ':00000001FF'
-
     eof = staticmethod(eof)
 
     def extended_segment_address(usba):
@@ -1166,9 +1154,8 @@ class Record(object):
         @param  usba     Upper Segment Base Address.
         @return         String representation of Intel Hex USBA record.
         """
-        b = [2, 0, 0, 0x02, (usba >> 8) & 0x0FF, usba & 0x0FF]
+        b = [2, 0, 0, 0x02, (usba>>8)&0x0FF, usba&0x0FF]
         return Record._from_bytes(b)
-
     extended_segment_address = staticmethod(extended_segment_address)
 
     def start_segment_address(cs, ip):
@@ -1177,10 +1164,9 @@ class Record(object):
         @param  ip      16-bit value for IP register.
         @return         String representation of Intel Hex SSA record.
         """
-        b = [4, 0, 0, 0x03, (cs >> 8) & 0x0FF, cs & 0x0FF,
-             (ip >> 8) & 0x0FF, ip & 0x0FF]
+        b = [4, 0, 0, 0x03, (cs>>8)&0x0FF, cs&0x0FF,
+             (ip>>8)&0x0FF, ip&0x0FF]
         return Record._from_bytes(b)
-
     start_segment_address = staticmethod(start_segment_address)
 
     def extended_linear_address(ulba):
@@ -1188,9 +1174,8 @@ class Record(object):
         @param  ulba    Upper Linear Base Address.
         @return         String representation of Intel Hex ELA record.
         """
-        b = [2, 0, 0, 0x04, (ulba >> 8) & 0x0FF, ulba & 0x0FF]
+        b = [2, 0, 0, 0x04, (ulba>>8)&0x0FF, ulba&0x0FF]
         return Record._from_bytes(b)
-
     extended_linear_address = staticmethod(extended_linear_address)
 
     def start_linear_address(eip):
@@ -1198,17 +1183,15 @@ class Record(object):
         @param  eip     32-bit linear address for the EIP register.
         @return         String representation of Intel Hex SLA record.
         """
-        b = [4, 0, 0, 0x05, (eip >> 24) & 0x0FF, (eip >> 16) & 0x0FF,
-             (eip >> 8) & 0x0FF, eip & 0x0FF]
+        b = [4, 0, 0, 0x05, (eip>>24)&0x0FF, (eip>>16)&0x0FF,
+             (eip>>8)&0x0FF, eip&0x0FF]
         return Record._from_bytes(b)
-
     start_linear_address = staticmethod(start_linear_address)
 
 
 class _BadFileNotation(Exception):
     """Special error class to use with _get_file_and_addr_range."""
     pass
-
 
 def _get_file_and_addr_range(s, _support_drive_letter=None):
     """Special method for hexmerge.py script to split file notation
@@ -1219,7 +1202,7 @@ def _get_file_and_addr_range(s, _support_drive_letter=None):
         _support_drive_letter = (os.name == 'nt')
     drive = ''
     if _support_drive_letter:
-        if s[1:2] == ':' and s[0].upper() in ''.join([chr(i) for i in range_g(ord('A'), ord('Z') + 1)]):
+        if s[1:2] == ':' and s[0].upper() in ''.join([chr(i) for i in range_g(ord('A'), ord('Z')+1)]):
             drive = s[:2]
             s = s[2:]
     parts = s.split(':')
@@ -1232,7 +1215,6 @@ def _get_file_and_addr_range(s, _support_drive_letter=None):
         raise _BadFileNotation
     else:
         fname = parts[0]
-
         def ascii_hex_to_int(ascii):
             if ascii is not None:
                 try:
@@ -1240,10 +1222,9 @@ def _get_file_and_addr_range(s, _support_drive_letter=None):
                 except ValueError:
                     raise _BadFileNotation
             return ascii
-
         fstart = ascii_hex_to_int(parts[1] or None)
         fend = ascii_hex_to_int(parts[2] or None)
-    return drive + fname, fstart, fend
+    return drive+fname, fstart, fend
 
 
 ##
@@ -1273,7 +1254,7 @@ def _get_file_and_addr_range(s, _support_drive_letter=None):
 class IntelHexError(Exception):
     '''Base Exception class for IntelHex module'''
 
-    _fmt = 'IntelHex base error'  #: format string
+    _fmt = 'IntelHex base error'   #: format string
 
     def __init__(self, msg=None, **kw):
         """Initialize the Exception with the given message.
@@ -1289,23 +1270,19 @@ class IntelHexError(Exception):
         try:
             return self._fmt % self.__dict__
         except (NameError, ValueError, KeyError):
-            e = sys.exc_info()[1]  # current exception
+            e = sys.exc_info()[1]     # current exception
             return 'Unprintable exception %s: %s' \
-                   % (repr(e), str(e))
-
+                % (repr(e), str(e))
 
 class _EndOfFile(IntelHexError):
     """Used for internal needs only."""
     _fmt = 'EOF record reached -- signal to stop read file'
 
-
 class HexReaderError(IntelHexError):
     _fmt = 'Hex reader base error'
 
-
 class AddressOverlapError(HexReaderError):
     _fmt = 'Hex file has data overlap at address 0x%(address)X on line %(line)d'
-
 
 # class NotAHexFileError was removed in trunk.revno.54 because it's not used
 
@@ -1317,14 +1294,11 @@ class HexRecordError(HexReaderError):
 class RecordLengthError(HexRecordError):
     _fmt = 'Record at line %(line)d has invalid length'
 
-
 class RecordTypeError(HexRecordError):
     _fmt = 'Record at line %(line)d has invalid record type'
 
-
 class RecordChecksumError(HexRecordError):
     _fmt = 'Record at line %(line)d has invalid checksum'
-
 
 class EOFRecordError(HexRecordError):
     _fmt = 'File has invalid End-of-File record'
@@ -1333,10 +1307,8 @@ class EOFRecordError(HexRecordError):
 class ExtendedAddressRecordError(HexRecordError):
     _fmt = 'Base class for extended address exceptions'
 
-
 class ExtendedSegmentAddressRecordError(ExtendedAddressRecordError):
     _fmt = 'Invalid Extended Segment Address Record at line %(line)d'
-
 
 class ExtendedLinearAddressRecordError(ExtendedAddressRecordError):
     _fmt = 'Invalid Extended Linear Address Record at line %(line)d'
@@ -1345,18 +1317,14 @@ class ExtendedLinearAddressRecordError(ExtendedAddressRecordError):
 class StartAddressRecordError(HexRecordError):
     _fmt = 'Base class for start address exceptions'
 
-
 class StartSegmentAddressRecordError(StartAddressRecordError):
     _fmt = 'Invalid Start Segment Address Record at line %(line)d'
-
 
 class StartLinearAddressRecordError(StartAddressRecordError):
     _fmt = 'Invalid Start Linear Address Record at line %(line)d'
 
-
 class DuplicateStartAddressRecordError(StartAddressRecordError):
     _fmt = 'Start Address Record appears twice at line %(line)d'
-
 
 class InvalidStartAddressValueError(StartAddressRecordError):
     _fmt = 'Invalid start address value: %(start_addr)s'
@@ -1366,10 +1334,8 @@ class NotEnoughDataError(IntelHexError):
     _fmt = ('Bad access at 0x%(address)X: '
             'not enough data to read %(length)d contiguous bytes')
 
-
 class BadAccess16bit(NotEnoughDataError):
     _fmt = 'Bad access at 0x%(address)X: not enough data to read 16 bit value'
-
 
 class EmptyIntelHexError(IntelHexError):
     _fmt = "Requested operation cannot be executed with empty object"

--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -57,7 +57,6 @@ from intelhex.compat import (
 
 from intelhex.getsizeof import total_size
 
-
 class _DeprecatedParam(object):
     pass
 
@@ -949,7 +948,7 @@ class IntelHex16bit(IntelHex):
         byte2 = self._buf.get(addr2, None)
 
         if byte1 != None and byte2 != None:
-            return byte1 | (byte2 << 8)     # low endian
+            return byte2 | (byte1 << 8)     # low endian
 
         if byte1 == None and byte2 == None:
             return self.padding


### PR DESCRIPTION
I used a simple reverse algorithm to reverse the data bytes before writing them to the bin dictionary. Use it by specifying new argument "endian_mode" as "big" when calling write_hex_file().