### PR TITLE
Add explicit classifications for supported python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,14 @@ METADATA = dict(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
       ],
 )
 


### PR DESCRIPTION
Many tools such as [caniusepython3](https://pypi.org/project/caniusepython3/) rely on classification to determine library support.