### PR TITLE
Minor makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,21 @@
 PYTHON := python
 
+define HELP=
+Available targets:
+ clean   - clean build directory
+ test    - run unittest
+ epydoc  - run epydoc to create API documentation '(python 2)'
+ wininst - Windows installer for Python
+ docs    - build docs with ReST and Sphinx
+ wheel   - build python wheel binary archive
+
+endef
+
+export HELP
 all:
-	@echo Available targets:
-	@echo  clean   - clean build directory
-	@echo  test    - run unittest
-	@echo  epydoc  - run epydoc to create API documentation (python 2)
-	@echo  wininst - Windows installer for Python
-	@echo  docs    - build docs with ReST and Sphinx
-	@echo  wheel   - build python wheel binary archive
+	@echo "$$HELP"
 
 .PHONY: clean test epydoc wininst docs
-
 clean:
 	$(PYTHON) setup.py clean -a
 


### PR DESCRIPTION
On posix shell the bare `()` in the help text are interpreted as
subshell markers which gives this error:

```bash
❯ make
Available targets:
clean - clean build directory
test - run unittest
/bin/sh: 1: Syntax error: "(" unexpected
make: *** [Makefile:7: all] Error 2
```

Enclose the help text in a multiline variable and echo it out:

```bash
❯ make
Available targets:
 clean   - clean build directory
 test    - run unittest
 epydoc  - run epydoc to create API documentation '(python 2)'
 wininst - Windows installer for Python
 docs    - build docs with ReST and Sphinx
 wheel   - build python wheel binary archive
```