### PR TITLE
Use entrypoints for the scripts

### DIFF
--- a/intelhex/bench.py
+++ b/intelhex/bench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # (c) Alexander Belchenko, 2007, 2009
 
 # [2013/08] NOTE: This file is keeping for historical reasons.

--- a/intelhex/scripts/bin2hex.py
+++ b/intelhex/scripts/bin2hex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2008-2018 Alexander Belchenko
 # All rights reserved.
@@ -37,7 +37,7 @@
 
 VERSION = '2.3.0'
 
-if __name__ == '__main__':
+def main():
     import getopt
     import os
     import sys
@@ -113,3 +113,6 @@ Options:
 
     from intelhex import bin2hex
     sys.exit(bin2hex(fin, fout, offset))
+
+if __name__ == '__main__':
+    main()

--- a/intelhex/scripts/hex2bin.py
+++ b/intelhex/scripts/hex2bin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2005-2018 Alexander Belchenko
 # All rights reserved.
@@ -37,7 +37,7 @@
 
 VERSION = '2.3.0'
 
-if __name__ == '__main__':
+def main():
     import getopt
     import os
     import sys
@@ -130,3 +130,6 @@ Options:
 
     from intelhex import hex2bin
     sys.exit(hex2bin(fin, fout, start, end, size, pad))
+
+if __name__ == '__main__':
+    main()

--- a/intelhex/scripts/hex2dump.py
+++ b/intelhex/scripts/hex2dump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2008-2018 Alexander Belchenko
 # All rights reserved.

--- a/intelhex/scripts/hexdiff.py
+++ b/intelhex/scripts/hexdiff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2011-2018 Alexander Belchenko
 # All rights reserved.

--- a/intelhex/scripts/hexinfo.py
+++ b/intelhex/scripts/hexinfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2015 Andrew Fernandes <andrew@fernandes.org>
 # All rights reserved.

--- a/intelhex/scripts/hexmerge.py
+++ b/intelhex/scripts/hexmerge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2008-2018 Alexander Belchenko
 # All rights reserved.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[wheel]
+[bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2008-2018, Alexander Belchenko
 # All rights reserved.
@@ -35,7 +35,7 @@
 
 """Setup script for IntelHex."""
 
-import sys, glob
+import os, sys, glob
 try:
     from setuptools import setup
 except ImportError:
@@ -46,12 +46,24 @@ import intelhex, intelhex.__version__
 
 LONG_DESCRIPTION = open('README.rst', 'r').read()
 
+SCRIPT_MODULES = [os.path.splitext(x)[0] for x in glob.glob('intelhex/scripts/*')]
+
+print(SCRIPT_MODULES)
+
 METADATA = dict(
       name='intelhex',
       version=intelhex.__version__.version_str,
 
-      scripts=glob.glob('scripts/*'),
-      packages=['intelhex'],
+      # Include the scripts as a subpackage
+      packages=['intelhex', 'intelhex.scripts'],
+
+      # For every script file, add an entrypoint
+      entry_points={
+          "console_scripts": [
+              "{name}.py = intelhex.scripts.{name}:main".format(name=os.path.basename(x))
+              for x in SCRIPT_MODULES
+          ]
+      },
 
       author='Alexander Belchenko',
       author_email='alexander.belchenko@gmail.com',


### PR DESCRIPTION
Swap out `scripts` for entrypoints to ensure executable flag is properly
set when installing from wheel, and hashbang is correct for whatever
virtualenv/pipenv/etc the user might be user (instead of hardcoded to
`/usr/bin/python` and relying on `script` rewrite magic to fix it).

Fix a deprecation notice for setup.cfg.

_Note: moving `scripts` to `intelhex/scripts` means that the scripts
cannot be run as-is from their position in the file system. Recommended
approach when developing a package is to `pip install -e .` install in
editable mode and work from there._