### PR TITLE
Add option/parameters to strip padding from the end of binary data.

### DIFF
--- a/intelhex/scripts/hex2bin.py
+++ b/intelhex/scripts/hex2bin.py
@@ -37,6 +37,15 @@
 
 VERSION = '2.3.0'
 
+def split_range(a):
+    l = a.split(":")
+    if l[0] != '':
+        start = int(l[0], 16)
+    if l[1] != '':
+        end = int(l[1], 16)
+    return start, end
+
+
 def main():
     import getopt
     import os
@@ -58,21 +67,23 @@ Options:
     -r, --range=START:END   specify address range for writing output
                             (ascii hex value).
                             Range can be in form 'START:' or ':END'.
+    -f, --filter=START:END  specify address range for filtering input
+                            (ascii hex value).
+                            Filter range can be in form 'START:' or ':END'.
     -l, --length=NNNN,
     -s, --size=NNNN         size of output (decimal value).
-        --strip             strip padding from the end of the binary data.
 '''
 
     pad = None
     start = None
     end = None
     size = None
-    strip = False
+    filter = False
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hvp:r:l:s:",
+        opts, args = getopt.getopt(sys.argv[1:], "hvp:r:f:l:s:",
                                   ["help", "version", "pad=", "range=",
-                                   "length=", "size=", "strip"])
+                                   "filter", "length=", "size="])
 
         for o, a in opts:
             if o in ("-h", "--help"):
@@ -88,20 +99,20 @@ Options:
                     raise getopt.GetoptError('Bad pad value')
             elif o in ("-r", "--range"):
                 try:
-                    l = a.split(":")
-                    if l[0] != '':
-                        start = int(l[0], 16)
-                    if l[1] != '':
-                        end = int(l[1], 16)
+                    start, end = split_range(a)
                 except:
                     raise getopt.GetoptError('Bad range value(s)')
+            elif o in ("-f", "--filter"):
+                filter = True
+                try:
+                    start, end = split_range(a)
+                except:
+                    raise getopt.GetoptError('Bad filter range value(s)')
             elif o in ("-l", "--lenght", "-s", "--size"):
                 try:
                     size = int(a, 10)
                 except:
                     raise getopt.GetoptError('Bad size value')
-            elif o in ("--strip"):
-                strip = True
 
         if start != None and end != None and size != None:
             raise getopt.GetoptError('Cannot specify START:END and SIZE simultaneously')
@@ -133,7 +144,7 @@ Options:
         fout = compat.get_binary_stdout()
 
     from intelhex import hex2bin
-    sys.exit(hex2bin(fin, fout, start, end, size, pad, strip))
+    sys.exit(hex2bin(fin, fout, start, end, size, pad, filter))
 
 if __name__ == '__main__':
     main()

--- a/intelhex/scripts/hex2bin.py
+++ b/intelhex/scripts/hex2bin.py
@@ -60,17 +60,19 @@ Options:
                             Range can be in form 'START:' or ':END'.
     -l, --length=NNNN,
     -s, --size=NNNN         size of output (decimal value).
+        --strip             strip padding from the end of the binary data.
 '''
 
     pad = None
     start = None
     end = None
     size = None
+    strip = False
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hvp:r:l:s:",
                                   ["help", "version", "pad=", "range=",
-                                   "length=", "size="])
+                                   "length=", "size=", "strip"])
 
         for o, a in opts:
             if o in ("-h", "--help"):
@@ -98,6 +100,8 @@ Options:
                     size = int(a, 10)
                 except:
                     raise getopt.GetoptError('Bad size value')
+            elif o in ("--strip"):
+                strip = True
 
         if start != None and end != None and size != None:
             raise getopt.GetoptError('Cannot specify START:END and SIZE simultaneously')
@@ -129,7 +133,7 @@ Options:
         fout = compat.get_binary_stdout()
 
     from intelhex import hex2bin
-    sys.exit(hex2bin(fin, fout, start, end, size, pad))
+    sys.exit(hex2bin(fin, fout, start, end, size, pad, strip))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Sometimes when converting iHex -> binary and you specify a range, it is not because you want to _fill_ that range, but rather because you want to _limit_ the output to (at most) that range.

For example, a PIC18F might have 32kB of Flash, but has a few bytes of config memory that loads at address 3M. So when you create a .bin file for it, the 32kB part winds up with a 3MB binary! And, if you're loading the binary through a bootloader, you don't need the config memory anyway.

So, you might limit the range to 0x800:0x7FFF (above the bootloader to the end of Flash). But if the app is only 4kB, then >80% of the binary is padding, and sending it to the bootloader taks considerably longer than necessary.

This PR adds a `strip` option to the functions that output to binary, that can tell them to strip off any padding at the **end** of the binary array. It also adds a `--strip` option to the _hex2bin.py_ script to pass that option along.

This probably isn't an optimal solution, and I assume there's other ways to accomplish the same goal, but this update fit our needs.