### PR TITLE
Fixed spelling of 'length' in hex2bin.py script

### DIFF
--- a/intelhex/scripts/hex2bin.py
+++ b/intelhex/scripts/hex2bin.py
@@ -93,7 +93,7 @@ Options:
                         end = int(l[1], 16)
                 except:
                     raise getopt.GetoptError('Bad range value(s)')
-            elif o in ("-l", "--lenght", "-s", "--size"):
+            elif o in ("-l", "--length", "-s", "--size"):
                 try:
                     size = int(a, 10)
                 except:


### PR DESCRIPTION
The word "length" is spelled incorrectly in the parameter matching tuple. So if someone used the long param, it wouldn't match.