### PR TITLE
Make the max byte count configurable for bin2hex and hexmerge

### DIFF
--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -1081,13 +1081,14 @@ def hex2bin(fin, fout, start=None, end=None, size=None, pad=None):
 #/def hex2bin
 
 
-def bin2hex(fin, fout, offset=0):
+def bin2hex(fin, fout, offset=0, byte_count=16):
     """Simple bin-to-hex convertor.
     @return     0   if all OK
 
-    @param  fin     input bin file (filename or file-like object)
-    @param  fout    output hex file (filename or file-like object)
-    @param  offset  starting address offset for loading bin
+    @param  fin        input bin file (filename or file-like object)
+    @param  fout       output hex file (filename or file-like object)
+    @param  offset     starting address offset for loading bin
+    @param  byte_count bytes per line
     """
     h = IntelHex()
     try:
@@ -1099,7 +1100,7 @@ def bin2hex(fin, fout, offset=0):
         return 1
 
     try:
-        h.tofile(fout, format='hex')
+        h.tofile(fout, format='hex', byte_count=byte_count)
     except IOError:
         e = sys.exc_info()[1]     # current exception
         txt = "ERROR: Could not write to file: %s: %s" % (fout, str(e))

--- a/intelhex/scripts/bin2hex.py
+++ b/intelhex/scripts/bin2hex.py
@@ -57,9 +57,11 @@ Options:
     -h, --help              this help message.
     -v, --version           version info.
     --offset=N              offset for loading bin file (default: 0).
+    --byte-count=N          max bytes per line
 '''
 
     offset = 0
+    byte_count = 32
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hv",
@@ -80,6 +82,8 @@ Options:
                     offset = int(a, base)
                 except:
                     raise getopt.GetoptError('Bad offset value')
+            elif o in ("--byte-count"):
+                byte_count = int(a)
 
         if not args:
             raise getopt.GetoptError('Input file is not specified')
@@ -112,7 +116,7 @@ Options:
         fout = sys.stdout   # compat.get_binary_stdout()
 
     from intelhex import bin2hex
-    sys.exit(bin2hex(fin, fout, offset))
+    sys.exit(bin2hex(fin, fout, offset, byte_count))
 
 if __name__ == '__main__':
     main()

--- a/intelhex/scripts/hexmerge.py
+++ b/intelhex/scripts/hexmerge.py
@@ -57,6 +57,7 @@ Options:
                                         contains data at overlapped address
                             * replace -- use data from last file that
                                          contains data at overlapped address
+     --byte-count=N         max bytes per line
 
 Arguments:
     FILES       list of hex files for merging
@@ -91,6 +92,7 @@ def main(args=None):
     end = None
     write_start_addr = True
     overlap = 'error'
+    byte_count = 32
 
     if args is None:
         args = sys.argv[1:]
@@ -99,6 +101,7 @@ def main(args=None):
                                        ['help', 'version',
                                         'output=', 'range=',
                                         'no-start-addr', 'overlap=',
+                                        'byte-count='
                                        ])
 
         for o,a in opts:
@@ -126,6 +129,8 @@ def main(args=None):
                     overlap = a
                 else:
                     raise getopt.GetoptError('Bad overlap value')
+            elif o == '--byte-count':
+                byte_count = int(a)
 
         if len(args) == 0:
             raise getopt.GetoptError('You should specify file list')
@@ -170,7 +175,7 @@ def main(args=None):
         res = res[start:end_addr_inclusive(end)]
     if output is None:
         output = sys.stdout
-    res.write_hex_file(output, write_start_addr)
+    res.write_hex_file(output, write_start_addr, byte_count=byte_count)
     return 0
 
 


### PR DESCRIPTION
Lower layers already support tweaking this. So this simply adds the necessary knobs on the CLI tools.