### PR TITLE
Fix calculation of Segment Address (Record 02)

### DIFF
--- a/intelhex/__init__.py
+++ b/intelhex/__init__.py
@@ -158,7 +158,7 @@ class IntelHex(object):
             # Extended 8086 Segment Record
             if record_length != 2 or addr != 0:
                 raise ExtendedSegmentAddressRecordError(line=line)
-            self._offset = (bin[4]*256 + bin[5]) * 16
+            self._offset = (self._offset & 0xFFF00000 ) | ((bin[4]*256 + bin[5]) * 16)
 
         elif record_type == 4:
             # Extended Linear Address Record


### PR DESCRIPTION
Record 02 only changes bits 0-19 of linear address (where bits 0-3 are zero and bits 4-19 are specified). Bits 20-31 should not be modified.